### PR TITLE
Add `limit` and `offset` parameters to the Search Query within the Telicent Graph Schema (CORE-355)

### DIFF
--- a/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/fetchers/telicent/graph/StartingSearchFetcher.java
+++ b/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/fetchers/telicent/graph/StartingSearchFetcher.java
@@ -1,11 +1,11 @@
 /**
  * Copyright (C) Telicent Ltd
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
- *
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
@@ -83,14 +83,14 @@ public class StartingSearchFetcher implements DataFetcher<List<TelicentGraphNode
 
         // Make a search to populate the starts filter
         String searchTerm = environment.getArgument("searchTerm");
-        if(StringUtils.isBlank(searchTerm)) {
-            throw new RuntimeException(
-                    "Failed to make query as no 'searchTerm' argument provided");
+        if (StringUtils.isBlank(searchTerm)) {
+            throw new RuntimeException("Failed to make query as no 'searchTerm' argument provided");
         }
+        Integer limit = environment.getArgument("limit");
+        Integer offset = environment.getArgument("offset");
         List<Node> startFilters = new ArrayList<>();
         HttpRequest.Builder request =
-                HttpRequest.newBuilder(URI.create(this.searchApiUrl + "/documents?query=" + URLEncoder.encode(
-                        searchTerm, StandardCharsets.UTF_8))).GET();
+                HttpRequest.newBuilder(buildSearchApiRequestUri(this.searchApiUrl, searchTerm, limit, offset)).GET();
         if (context.hasAuthToken()) {
             // If we have an authentication token need to copy it to our search request so that our request reflects the
             // requesting users data access
@@ -104,8 +104,8 @@ public class StartingSearchFetcher implements DataFetcher<List<TelicentGraphNode
                              .header(AwsConstants.HEADER_DATA, context.getAuthToken());
         }
         try {
-            HttpResponse<InputStream> response = client.send(request.build(),
-                                                             HttpResponse.BodyHandlers.ofInputStream());
+            HttpResponse<InputStream> response =
+                    client.send(request.build(), HttpResponse.BodyHandlers.ofInputStream());
             if (response.statusCode() == HttpSC.OK_200) {
                 Map<String, Object> results = JSON.readValue(response.body(), GraphQLOverHttp.GENERIC_MAP_TYPE);
 
@@ -113,7 +113,7 @@ public class StartingSearchFetcher implements DataFetcher<List<TelicentGraphNode
                     List<Map<String, Object>> searchResults = (List<Map<String, Object>>) results.get("results");
                     for (Map<String, Object> result : searchResults) {
                         if (result.containsKey("document")) {
-                            String docUri = (String) ((Map<String, Object>)result.get("document")).get("uri");
+                            String docUri = (String) ((Map<String, Object>) result.get("document")).get("uri");
                             if (StringUtils.isNotBlank(docUri)) {
                                 startFilters.add(StartingNodesFetcher.parseStart(docUri));
                             }
@@ -121,13 +121,12 @@ public class StartingSearchFetcher implements DataFetcher<List<TelicentGraphNode
                     }
                 }
             } else {
-                throw new RuntimeException(
-                        "Failed to make query for search term " + environment.getArgument(
-                                "searchTerm") + ", received status " + response.statusCode());
+                throw new RuntimeException("Failed to make query for search term " + environment.getArgument(
+                        "searchTerm") + ", received status " + response.statusCode());
             }
         } catch (Throwable e) {
-            throw new RuntimeException("Failed to make query for search term " + environment.getArgument("searchTerm") + ".  Search service may be unavailable in your environment.",
-                                       e);
+            throw new RuntimeException("Failed to make query for search term " + environment.getArgument(
+                    "searchTerm") + ".  Search service may be unavailable in your environment.", e);
         }
 
         return startFilters.stream()
@@ -137,6 +136,28 @@ public class StartingSearchFetcher implements DataFetcher<List<TelicentGraphNode
                            .distinct()
                            .map(n -> new TelicentGraphNode(n, dsg.prefixes()))
                            .collect(Collectors.toList());
+    }
+
+    /**
+     * Builds the API used to issue Search Requests to the underlying Searcn API
+     * @param searchApiUrl
+     * @param searchTerm
+     * @param limit
+     * @param offset
+     * @return
+     */
+    public static URI buildSearchApiRequestUri(String searchApiUrl, String searchTerm, Integer limit, Integer offset) {
+        StringBuilder builder = new StringBuilder();
+        builder.append(searchApiUrl)
+               .append("/documents?query=")
+               .append(URLEncoder.encode(searchTerm, StandardCharsets.UTF_8));
+        if (limit != null && limit > 0) {
+            builder.append("&limit=").append(limit);
+        }
+        if (offset != null && offset >= 1) {
+            builder.append("&offset=").append(offset);
+        }
+        return URI.create(builder.toString());
     }
 
     private void configureSearchApiUrl() {

--- a/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/fetchers/telicent/graph/StartingSearchFetcher.java
+++ b/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/fetchers/telicent/graph/StartingSearchFetcher.java
@@ -1,11 +1,11 @@
 /**
  * Copyright (C) Telicent Ltd
- * <p>
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
- * <p>
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.

--- a/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/fetchers/telicent/graph/StartingSearchFetcher.java
+++ b/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/fetchers/telicent/graph/StartingSearchFetcher.java
@@ -139,12 +139,12 @@ public class StartingSearchFetcher implements DataFetcher<List<TelicentGraphNode
     }
 
     /**
-     * Builds the API used to issue Search Requests to the underlying Searcn API
-     * @param searchApiUrl
-     * @param searchTerm
-     * @param limit
-     * @param offset
-     * @return
+     * Builds the API used to issue Search Requests to the underlying Search API
+     * @param searchApiUrl Base Search API URL
+     * @param searchTerm Search Term
+     * @param limit Optional limit, ignored if {@code null} or not greater than {@code 0}
+     * @param offset Optional offset, ignored if {@code null} or not greater than {@code 0}
+     * @return Search API Request URL
      */
     public static URI buildSearchApiRequestUri(String searchApiUrl, String searchTerm, Integer limit, Integer offset) {
         StringBuilder builder = new StringBuilder();

--- a/telicent-graph-schema/src/main/resources/io/telicent/jena/graphql/schemas/telicent/graph/ies.graphqls
+++ b/telicent-graph-schema/src/main/resources/io/telicent/jena/graphql/schemas/telicent/graph/ies.graphqls
@@ -45,6 +45,8 @@ type Query {
     search(
         graph: String
         searchTerm: String!
+        limit: Int
+        offset: Int
     ): [Node]
     getAllEntities(graph: String): [Node]
     states(uri: String!): [State]!

--- a/telicent-graph-schema/src/test/java/io/telicent/jena/graphql/execution/telicent/graph/TestTelicentGraphExecution.java
+++ b/telicent-graph-schema/src/test/java/io/telicent/jena/graphql/execution/telicent/graph/TestTelicentGraphExecution.java
@@ -36,16 +36,16 @@ public class TestTelicentGraphExecution extends AbstractExecutionTests {
         JenaSystem.init();
     }
 
-    private static final String QUERY_BASE = "/queries/telicent/graph/";
+    public static final String QUERY_BASE = "/queries/telicent/graph/";
     public static final String OBI_WAN_KENOBI = "https://starwars.com#person_Obi-WanKenobi";
 
     public static final String JABBA_THE_HUT = "https://starwars.com#hutt_JabbaDesilijicTiure";
 
-    private static String loadQuery(String queryResource) {
+    public static String loadQuery(String queryResource) {
         return loadQuery(QUERY_BASE, queryResource);
     }
 
-    private static GraphQLRequest loadRequest(String requestResource) {
+    public static GraphQLRequest loadRequest(String requestResource) {
         return loadRequest(QUERY_BASE, requestResource);
     }
 

--- a/telicent-graph-schema/src/test/java/io/telicent/jena/graphql/execution/telicent/graph/TestTelicentGraphSearchExecution.java
+++ b/telicent-graph-schema/src/test/java/io/telicent/jena/graphql/execution/telicent/graph/TestTelicentGraphSearchExecution.java
@@ -1,0 +1,109 @@
+/**
+ * Copyright (C) Telicent Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.telicent.jena.graphql.execution.telicent.graph;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.tomakehurst.wiremock.WireMockServer;
+import graphql.ExecutionResult;
+import io.telicent.jena.graphql.execution.AbstractExecutionTests;
+import io.telicent.jena.graphql.schemas.telicent.graph.TelicentGraphSchema;
+import io.telicent.jena.graphql.server.model.GraphQLRequest;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.jena.riot.Lang;
+import org.apache.jena.riot.RDFParserBuilder;
+import org.apache.jena.sparql.core.DatasetGraph;
+import org.apache.jena.sparql.core.DatasetGraphFactory;
+import org.apache.jena.sys.JenaSystem;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterTest;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+
+@SuppressWarnings("unchecked")
+public class TestTelicentGraphSearchExecution extends AbstractExecutionTests {
+
+    private static ObjectMapper MAPPER = new ObjectMapper();
+
+    private static WireMockServer WIRE_MOCK_SERVER;
+
+    @BeforeClass
+    public static void setupClass() throws JsonProcessingException {
+        WIRE_MOCK_SERVER = new WireMockServer(wireMockConfig().port(8181));
+        WIRE_MOCK_SERVER.start();
+
+        Map<String, ?> pagedData = Map.of("limit", "10", "offset", "20", "results", List.of(Map.of("document",
+                                                                                                   Map.of("uri",
+                                                                                                          TestTelicentGraphExecution.OBI_WAN_KENOBI))));
+        WIRE_MOCK_SERVER.stubFor(get(urlEqualTo("/documents?query=test&limit=10&offset=20")).willReturn(
+                ok().withBody(MAPPER.writeValueAsString(pagedData))));
+    }
+
+    @AfterClass
+    public static void cleanUp() {
+        WIRE_MOCK_SERVER.stop();
+    }
+
+    public static final String PAGED_SEARCH_QUERY = TestTelicentGraphExecution.loadQuery("paged-search.graphql");
+    public static final String MALFORMED_PAGED_SEARCH_QUERY =
+            TestTelicentGraphExecution.loadQuery("malformed-paged-search.graphql");
+
+    private final TelicentGraphExecutor executor;
+
+    public TestTelicentGraphSearchExecution() throws IOException {
+        DatasetGraph dsg = RDFParserBuilder.create()
+                                           .lang(Lang.TURTLE)
+                                           .source(TestTelicentGraphSearchExecution.class.getResourceAsStream(
+                                                   "/data/starwars.ttl"))
+                                           .toDatasetGraph();
+        this.executor = new TelicentGraphExecutor(dsg);
+    }
+
+    @Test
+    public void givenPagedSearchQuery_whenExecuting_thenSuccess() {
+        // Given and When
+        ExecutionResult result = verifyExecution(this.executor, PAGED_SEARCH_QUERY);
+
+        // Then
+        Assert.assertTrue(result.isDataPresent());
+        Assert.assertNotNull(result.getData());
+        Map<String, Object> data = result.getData();
+        Assert.assertNotNull(data.get(TelicentGraphSchema.QUERY_SEARCH));
+        List<Map<String, Object>> searchResults =
+                (List<Map<String, Object>>) data.get(TelicentGraphSchema.QUERY_SEARCH);
+        Assert.assertFalse(searchResults.isEmpty());
+        Assert.assertEquals(searchResults.size(), 1);
+        Map<String, Object> firstResult = searchResults.get(0);
+        Assert.assertEquals(firstResult.get("uri"), TestTelicentGraphExecution.OBI_WAN_KENOBI);
+    }
+
+    @Test
+    public void givenMalformedPagedSearchQuery_whenExecuting_thenFails() {
+        // Given and When
+        ExecutionResult result = this.executor.execute(MALFORMED_PAGED_SEARCH_QUERY);
+
+        // Then
+        Assert.assertFalse(result.isDataPresent());
+        Assert.assertFalse(result.getErrors().isEmpty());
+        Assert.assertTrue(
+                result.getErrors().stream().allMatch(e -> StringUtils.contains(e.getMessage(), "not a valid 'Int'")));
+    }
+}

--- a/telicent-graph-schema/src/test/java/io/telicent/jena/graphql/execution/telicent/graph/TestTelicentGraphSearchExecution.java
+++ b/telicent-graph-schema/src/test/java/io/telicent/jena/graphql/execution/telicent/graph/TestTelicentGraphSearchExecution.java
@@ -18,16 +18,12 @@ import com.github.tomakehurst.wiremock.WireMockServer;
 import graphql.ExecutionResult;
 import io.telicent.jena.graphql.execution.AbstractExecutionTests;
 import io.telicent.jena.graphql.schemas.telicent.graph.TelicentGraphSchema;
-import io.telicent.jena.graphql.server.model.GraphQLRequest;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.jena.riot.Lang;
 import org.apache.jena.riot.RDFParserBuilder;
 import org.apache.jena.sparql.core.DatasetGraph;
-import org.apache.jena.sparql.core.DatasetGraphFactory;
-import org.apache.jena.sys.JenaSystem;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
-import org.testng.annotations.AfterTest;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 

--- a/telicent-graph-schema/src/test/java/io/telicent/jena/graphql/fetchers/telicent/graph/TestStartingSearchFetcher.java
+++ b/telicent-graph-schema/src/test/java/io/telicent/jena/graphql/fetchers/telicent/graph/TestStartingSearchFetcher.java
@@ -242,4 +242,37 @@ public class TestStartingSearchFetcher {
         Assert.assertTrue(actualList.isEmpty());
         WIRE_MOCK_SERVER.verify(getRequestedFor(urlEqualTo("/documents?query=test&limit=1&offset=2")));
     }
+
+    @Test(expectedExceptions = RuntimeException.class)
+    public void givenInvalidLimit_whenUsingSearchFetcher_thenErrorIsThrown()  {
+        // given
+        StartingSearchFetcher fetcher = new StartingSearchFetcher();
+        DatasetGraph dsg = createPagedSearchTestDataset();
+        TelicentExecutionContext context = new TelicentExecutionContext(dsg, "");
+        DataFetchingEnvironment environment = DataFetchingEnvironmentImpl
+                .newDataFetchingEnvironment()
+                .localContext(context)
+                .arguments(Map.of("searchTerm", "test", "limit", "foo"))
+                .build();
+        // when
+        // then
+        fetcher.get(environment);
+    }
+
+    @Test(expectedExceptions = RuntimeException.class)
+    public void givenInvalidOffset_whenUsingSearchFetcher_thenErrorIsThrown()  {
+        // given
+        StartingSearchFetcher fetcher = new StartingSearchFetcher();
+        DatasetGraph dsg = createPagedSearchTestDataset();
+        TelicentExecutionContext context = new TelicentExecutionContext(dsg, "");
+        DataFetchingEnvironment environment = DataFetchingEnvironmentImpl
+                .newDataFetchingEnvironment()
+                .localContext(context)
+                .arguments(Map.of("searchTerm", "test", "offset", "foo"))
+                .build();
+        // when
+        // then
+        fetcher.get(environment);
+    }
+
 }

--- a/telicent-graph-schema/src/test/resources/queries/telicent/graph/malformed-paged-search.graphql
+++ b/telicent-graph-schema/src/test/resources/queries/telicent/graph/malformed-paged-search.graphql
@@ -1,0 +1,7 @@
+query {
+    search(searchTerm: "test", limit: "10", offset: "20") {
+        id
+        uri
+        shortUri
+    }
+}

--- a/telicent-graph-schema/src/test/resources/queries/telicent/graph/malformed-paged-search.graphql
+++ b/telicent-graph-schema/src/test/resources/queries/telicent/graph/malformed-paged-search.graphql
@@ -1,4 +1,5 @@
 query {
+    # limit and offset MUST be integer values so this query will fail validation
     search(searchTerm: "test", limit: "10", offset: "20") {
         id
         uri

--- a/telicent-graph-schema/src/test/resources/queries/telicent/graph/paged-search.graphql
+++ b/telicent-graph-schema/src/test/resources/queries/telicent/graph/paged-search.graphql
@@ -1,0 +1,7 @@
+query {
+    search(searchTerm: "test", limit: 10, offset: 20) {
+        id
+        uri
+        shortUri
+    }
+}


### PR DESCRIPTION
This PR extends the existing Telicent Graph schema by adding new optional `limit` and `offset` arguments to the `search` query within the schema.  These are translated into the corresponding `limit` and `offset` parameters on the Search Request URL that gets built in `StartingSearchFetcher`.

Various new tests are added that verify the new functionality is correctly honoured.

# Related Issues and PRs

- This is progress on CORE-355, will need to generate a new release of this repository once this is merged and then upgrade SCG to include the latest release