### PR TITLE
Improved StartingNodesFetcher (CORE-386)

### DIFF
--- a/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/fetchers/telicent/graph/StartingNodesFetcher.java
+++ b/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/fetchers/telicent/graph/StartingNodesFetcher.java
@@ -21,7 +21,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.jena.graph.Node;
 import org.apache.jena.graph.NodeFactory;
 import org.apache.jena.sparql.core.DatasetGraph;
-import org.apache.jena.sparql.core.Quad;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -54,12 +53,14 @@ public class StartingNodesFetcher implements DataFetcher<Object> {
 
         List<TelicentGraphNode> nodes = startFilters.stream()
                                                     .distinct()
-                                                    .flatMap(n -> dsg.stream(graphFilter, n, Node.ANY, Node.ANY))
-                                                    .map(Quad::getSubject)
-                                                    .distinct()
+                                                    .filter(n -> usedAsSubjectOrObject(n, dsg, graphFilter))
                                                     .map(n -> new TelicentGraphNode(n, dsg.prefixes()))
                                                     .collect(Collectors.toList());
         return multiSelect ? nodes : (!nodes.isEmpty() ? nodes.get(0) : null);
+    }
+
+    private static boolean usedAsSubjectOrObject(Node n, DatasetGraph dsg, Node graphFilter) {
+        return dsg.contains(graphFilter, n, Node.ANY, Node.ANY) || dsg.contains(graphFilter, Node.ANY, Node.ANY, n);
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
Changed behaviour to return a Node supplied as a start purely on the basis of whether it has any triples using is as either a subject/object in the graph.  This is as opposed to the old code which returned nodes only if they were subjects of triples.

# Related Issues and PRs

- Tiny adjustment for CORE-386, likely nothing to do with the root cause of the data being missing from the dataset