### PR TITLE
Initial refactoring to enable searchV2() query (CORE-428)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # GraphQL Extensions for Apache Jena
 
+# 0.8.2
+
+- Telicent Graph Schema improvements:
+    - Added new `searchV2()` query with richer response schema
+    - Added optional `searchType` and `typeFilter` arguments to both `search()` and `searchV2()` queries
+    - Search queries have behavioural parity with `node()` and `nodes()` queries in treating any returned URI from
+      search as node if it occurs in the subject/object of any triples in the data
+
 # 0.8.1
 
 - Telicent Graph Schema now returns Nodes even if they only occur in the object position of triples in the data

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@
 # 0.8.2
 
 - Telicent Graph Schema improvements:
-    - Added new `searchV2()` query with richer response schema
-    - Added optional `searchType` and `typeFilter` arguments to both `search()` and `searchV2()` queries
+    - Added new `searchWithMetadata()` query with richer response schema
+    - Added optional `searchType` and `typeFilter` arguments to both `search()` and `searchWithMetadata()` queries
     - Search queries have behavioural parity with `node()` and `nodes()` queries in treating any returned URI from
       search as node if it occurs in the subject/object of any triples in the data
 

--- a/docs/schemas.md
+++ b/docs/schemas.md
@@ -280,7 +280,8 @@ these arguments may be used on both the `outgoing` and `incoming` fields.
 
 
 ## Telicent (IES)
-In telicent deployments, we make use of an Information Exchange Standard (IES) compliant schema. The IES is 
+
+In telicent deployments, we make use of an Information Exchange Standard (IES) compliant schema. The IES ontology is 
 an open standard developed by the UK Government for making the sharing of information across knowledge stores easier 
 and less complex by means of a common vocabulary. More information can be found [here](https://github.com/dstl/IES4)
 
@@ -331,21 +332,53 @@ type NonDirectionalRel {
     predicate: String!
     entity: Node!
 }
+
+enum SearchType {
+    QUERY,
+    TERM,
+    PHRASE,
+    WILDCARD
+}
+
+type SearchResults {
+    searchTerm: String!
+    searchType: SearchType!
+    limit: Int!
+    offset: Int!
+    maybeMore: Boolean!
+    nodes: [Node]
+}
 ```
 
-Furthermore, the following Query types are defined for operations that should be self-evident:
-- search
-- getAllEntities
-- states
-- node
-- nodes
+While this is still fairly RDF centric it models data quite differently than the simpler [Dataset](#dataset) or
+[Traversal](#traversal) schemas do, and includes higher level IES concepts like states.  It has the following query
+operations defined:
+
+- `search` and `searchV2` for using a search against Telicent Search API as the starting point for retrieving nodes in 
+  the dataset
+- `getAllEntities` for retreiving all nodes in the dataset
+- `states` for retrieving states (an IES ontology concept) of other entities in the dataset
+- `node` for retrieving a single ndoe from the dataset
+- `nodes` for retrieving multiple nodes from the dataset
 
 ```graphql
 type Query {
     search(
         graph: String
         searchTerm: String!
-    ): [Node]
+        searchType: SearchType
+        limit: Int
+        offset: Int
+        typeFilter: String
+    ): [Node] @deprecated(reason: "Use `searchV2` which offers richer response schema")
+    searchV2(
+        graph: String
+        searchTerm: String!
+        searchType: SearchType
+        limit: Int
+        offset: Int
+        typeFilter: String
+    ): SearchResults
     getAllEntities(graph: String): [Node]
     states(uri: String!): [State]!
     node(graph: String, uri: String!): Node

--- a/docs/schemas.md
+++ b/docs/schemas.md
@@ -354,9 +354,10 @@ While this is still fairly RDF centric it models data quite differently than the
 [Traversal](#traversal) schemas do, and includes higher level IES concepts like states.  It has the following query
 operations defined:
 
-- `search` and `searchV2` for using a search against Telicent Search API as the starting point for retrieving nodes in 
+- `search` and `searchWithMetadata` for using a search against Telicent Search API as the starting point for retrieving 
+  nodes in 
   the dataset
-- `getAllEntities` for retreiving all nodes in the dataset
+- `getAllEntities` for retrieving all nodes in the dataset
 - `states` for retrieving states (an IES ontology concept) of other entities in the dataset
 - `node` for retrieving a single ndoe from the dataset
 - `nodes` for retrieving multiple nodes from the dataset
@@ -370,8 +371,8 @@ type Query {
         limit: Int
         offset: Int
         typeFilter: String
-    ): [Node] @deprecated(reason: "Use `searchV2` which offers richer response schema")
-    searchV2(
+    ): [Node] @deprecated(reason: "Use `searchWithMetadata` which offers richer response schema")
+    searchWithMetadata(
         graph: String
         searchTerm: String!
         searchType: SearchType

--- a/graphql-jena-core/src/test/java/io/telicent/jena/graphql/fetchers/TestQuadsFetcher.java
+++ b/graphql-jena-core/src/test/java/io/telicent/jena/graphql/fetchers/TestQuadsFetcher.java
@@ -12,7 +12,6 @@
  */
 package io.telicent.jena.graphql.fetchers;
 
-import graphql.Assert;
 import graphql.schema.DataFetchingEnvironment;
 import graphql.schema.DataFetchingEnvironmentImpl;
 import graphql.schema.DataFetchingFieldSelectionSet;
@@ -20,6 +19,7 @@ import graphql.schema.SelectedField;
 import org.apache.jena.sparql.core.DatasetGraph;
 import org.apache.jena.sparql.core.DatasetGraphFactory;
 import org.apache.jena.sparql.core.Quad;
+import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 

--- a/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/execution/telicent/graph/TelicentGraphExecutor.java
+++ b/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/execution/telicent/graph/TelicentGraphExecutor.java
@@ -13,12 +13,15 @@
 package io.telicent.jena.graphql.execution.telicent.graph;
 
 import graphql.schema.PropertyDataFetcher;
+import graphql.schema.idl.NaturalEnumValuesProvider;
 import graphql.schema.idl.RuntimeWiring;
 import graphql.schema.idl.TypeDefinitionRegistry;
 import io.telicent.jena.graphql.execution.AbstractDatasetExecutor;
 import io.telicent.jena.graphql.fetchers.telicent.graph.*;
 import io.telicent.jena.graphql.schemas.models.EdgeDirection;
+import io.telicent.jena.graphql.schemas.models.NodeKind;
 import io.telicent.jena.graphql.schemas.telicent.graph.TelicentGraphSchema;
+import io.telicent.jena.graphql.schemas.telicent.graph.models.SearchType;
 import org.apache.jena.sparql.core.DatasetGraph;
 
 import java.io.IOException;
@@ -52,12 +55,14 @@ public class TelicentGraphExecutor extends AbstractDatasetExecutor {
     @Override
     protected RuntimeWiring.Builder buildRuntimeWiring() {
         final StatePeriodFetcher periodFetcher = new StatePeriodFetcher();
+        NaturalEnumValuesProvider<SearchType> nodeKinds = new NaturalEnumValuesProvider<>(SearchType.class);
         //@formatter:off
         return RuntimeWiring.newRuntimeWiring()
                             .type("Query",
                                   t -> t.dataFetcher(TelicentGraphSchema.QUERY_SINGLE_NODE, new StartingNodesFetcher(false))
                                         .dataFetcher(TelicentGraphSchema.QUERY_MULTIPLE_NODES, new StartingNodesFetcher(true))
                                         .dataFetcher(TelicentGraphSchema.QUERY_SEARCH, new StartingSearchFetcher())
+                                        .dataFetcher(TelicentGraphSchema.QUERY_SEARCH_V2, new StartingSearchV2Fetcher()).enumValues(nodeKinds)
                                         .dataFetcher(TelicentGraphSchema.QUERY_STATES, new StartingStatesFetcher())
                                         .dataFetcher(TelicentGraphSchema.QUERY_GET_ALL_ENTITIES, new AllEntitiesFetcher()))
                             .type(TelicentGraphSchema.TYPE_NODE,

--- a/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/execution/telicent/graph/TelicentGraphExecutor.java
+++ b/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/execution/telicent/graph/TelicentGraphExecutor.java
@@ -19,7 +19,6 @@ import graphql.schema.idl.TypeDefinitionRegistry;
 import io.telicent.jena.graphql.execution.AbstractDatasetExecutor;
 import io.telicent.jena.graphql.fetchers.telicent.graph.*;
 import io.telicent.jena.graphql.schemas.models.EdgeDirection;
-import io.telicent.jena.graphql.schemas.models.NodeKind;
 import io.telicent.jena.graphql.schemas.telicent.graph.TelicentGraphSchema;
 import io.telicent.jena.graphql.schemas.telicent.graph.models.SearchType;
 import org.apache.jena.sparql.core.DatasetGraph;

--- a/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/execution/telicent/graph/TelicentGraphExecutor.java
+++ b/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/execution/telicent/graph/TelicentGraphExecutor.java
@@ -61,7 +61,7 @@ public class TelicentGraphExecutor extends AbstractDatasetExecutor {
                                   t -> t.dataFetcher(TelicentGraphSchema.QUERY_SINGLE_NODE, new StartingNodesFetcher(false))
                                         .dataFetcher(TelicentGraphSchema.QUERY_MULTIPLE_NODES, new StartingNodesFetcher(true))
                                         .dataFetcher(TelicentGraphSchema.QUERY_SEARCH, new StartingSearchFetcher())
-                                        .dataFetcher(TelicentGraphSchema.QUERY_SEARCH_V2, new StartingSearchV2Fetcher()).enumValues(nodeKinds)
+                                        .dataFetcher(TelicentGraphSchema.QUERY_SEARCH_WITH_METADATA, new StartingSearchWithMetadataFetcher()).enumValues(nodeKinds)
                                         .dataFetcher(TelicentGraphSchema.QUERY_STATES, new StartingStatesFetcher())
                                         .dataFetcher(TelicentGraphSchema.QUERY_GET_ALL_ENTITIES, new AllEntitiesFetcher()))
                             .type(TelicentGraphSchema.TYPE_NODE,

--- a/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/fetchers/telicent/graph/AbstractSearchFetcher.java
+++ b/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/fetchers/telicent/graph/AbstractSearchFetcher.java
@@ -1,0 +1,189 @@
+/**
+ * Copyright (C) Telicent Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.telicent.jena.graphql.fetchers.telicent.graph;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import graphql.schema.DataFetcher;
+import graphql.schema.DataFetchingEnvironment;
+import io.telicent.jena.graphql.execution.telicent.graph.TelicentExecutionContext;
+import io.telicent.jena.graphql.schemas.telicent.graph.TelicentGraphSchema;
+import io.telicent.jena.graphql.schemas.telicent.graph.models.SearchType;
+import io.telicent.jena.graphql.schemas.telicent.graph.models.TelicentGraphNode;
+import io.telicent.jena.graphql.schemas.telicent.graph.models.TelicentSearchResults;
+import io.telicent.jena.graphql.server.model.GraphQLOverHttp;
+import io.telicent.servlet.auth.jwt.JwtHttpConstants;
+import io.telicent.servlet.auth.jwt.verifier.aws.AwsConstants;
+import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.jena.graph.Node;
+import org.apache.jena.sparql.core.DatasetGraph;
+import org.apache.jena.sparql.core.Quad;
+import org.apache.jena.web.HttpSC;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.InputStream;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * An abstract GraphQL fetcher for Search based queries
+ */
+public abstract class AbstractSearchFetcher<T> implements DataFetcher<T> {
+    /**
+     * The environment variable/system property used to configure the Search API URL
+     */
+    public static final String ENV_SEARCH_API_URL = "SEARCH_API_URL";
+    /**
+     * The default Search API URL used if none was supplied
+     */
+    public static final String DEFAULT_SEARCH_API_URL = "http://localhost:8181";
+    private static final Logger LOGGER = LoggerFactory.getLogger(AbstractSearchFetcher.class);
+    private static final ObjectMapper JSON = new ObjectMapper();
+    private final HttpClient client = HttpClient.newBuilder().build();
+    private String searchApiUrl = null;
+
+    /**
+     * Builds the API used to issue Search Requests to the underlying Search API
+     *
+     * @param searchApiUrl Base Search API URL
+     * @param searchTerm   Search Term
+     * @param environment  Data Fetching Environment
+     * @return Search API Request URL
+     */
+    public static URI buildSearchApiRequestUri(String searchApiUrl, String searchTerm,
+                                               DataFetchingEnvironment environment) {
+        StringBuilder builder = new StringBuilder();
+        builder.append(searchApiUrl)
+               .append("/documents?query=")
+               .append(URLEncoder.encode(searchTerm, StandardCharsets.UTF_8));
+
+        // Add optional parameters
+        SearchType searchType = environment.getArgument(TelicentGraphSchema.ARGUMENT_SEARCH_TYPE);
+        if (searchType != null) {
+            builder.append("&type=").append(searchType.name().toLowerCase(Locale.ROOT));
+        }
+        Integer limit = environment.getArgument(TelicentGraphSchema.ARGUMENT_LIMIT);
+        if (limit != null && limit > 0) {
+            builder.append("&limit=").append(limit);
+        }
+        Integer offset = environment.getArgument(TelicentGraphSchema.ARGUMENT_OFFSET);
+        if (offset != null && offset >= 1) {
+            builder.append("&offset=").append(offset);
+        }
+        String typeFilter = environment.getArgument(TelicentGraphSchema.ARGUMENT_TYPE_FILTER);
+        if (StringUtils.isNotBlank(typeFilter)) {
+            builder.append("&typeFilter=")
+                   .append(Base64.encodeBase64URLSafeString(typeFilter.getBytes(StandardCharsets.UTF_8)))
+                   .append("is-type-filter-base64=true");
+        }
+        return URI.create(builder.toString());
+    }
+
+    private static String findSearchApiUrl() {
+        // Try the environment variable first
+        String envValue = System.getenv(ENV_SEARCH_API_URL);
+        if (StringUtils.isNotBlank(envValue)) {
+            return envValue;
+        }
+        // Try the system property second, falling back to the default value if not available
+        return System.getProperty(ENV_SEARCH_API_URL, DEFAULT_SEARCH_API_URL);
+    }
+
+    @SuppressWarnings("unchecked")
+    protected TelicentSearchResults searchCommon(DataFetchingEnvironment environment) {
+        configureSearchApiUrl();
+
+        TelicentExecutionContext context = environment.getLocalContext();
+        DatasetGraph dsg = context.getDatasetGraph();
+        String rawGraph = environment.getArgument(TelicentGraphSchema.ARGUMENT_GRAPH);
+        Node graphFilter = StringUtils.isNotBlank(rawGraph) ? StartingNodesFetcher.parseStart(rawGraph) : Node.ANY;
+
+        // Make a search to populate the starts filter
+        String searchTerm = environment.getArgument(TelicentGraphSchema.ARGUMENT_SEARCH_TERM);
+        if (StringUtils.isBlank(searchTerm)) {
+            throw new RuntimeException("Failed to make query as no 'searchTerm' argument provided");
+        }
+        List<Node> startFilters = new ArrayList<>();
+        HttpRequest.Builder request =
+                HttpRequest.newBuilder(
+                                   AbstractSearchFetcher.buildSearchApiRequestUri(this.searchApiUrl, searchTerm, environment))
+                           .GET();
+        if (context.hasAuthToken()) {
+            // If we have an authentication token need to copy it to our search request so that our request reflects the
+            // requesting users data access
+            // Note that since this code doesn't know its deployment context we don't know how the token originally
+            // was provided to us so when talking to another HTTP service within the platform pass it in the two main
+            // ways that service might expect to receive it. In an AWS context this might mean that the requests pass
+            // back via the ELB which is applying the necessary token(s) anyway but no harm in manually adding it
+            // ourselves.
+            request = request.header(JwtHttpConstants.HEADER_AUTHORIZATION,
+                                     JwtHttpConstants.AUTH_SCHEME_BEARER + " " + context.getAuthToken())
+                             .header(AwsConstants.HEADER_DATA, context.getAuthToken());
+        }
+        TelicentSearchResults telicentResults = null;
+        try {
+            HttpResponse<InputStream> response =
+                    client.send(request.build(), HttpResponse.BodyHandlers.ofInputStream());
+            if (response.statusCode() == HttpSC.OK_200) {
+                Map<String, Object> results = JSON.readValue(response.body(), GraphQLOverHttp.GENERIC_MAP_TYPE);
+                telicentResults = TelicentSearchResults.fromMap(results);
+
+                if (results.containsKey("results")) {
+                    List<Map<String, Object>> searchResults = (List<Map<String, Object>>) results.get("results");
+                    for (Map<String, Object> result : searchResults) {
+                        if (result.containsKey("document")) {
+                            String docUri = (String) ((Map<String, Object>) result.get("document")).get("uri");
+                            if (StringUtils.isNotBlank(docUri)) {
+                                startFilters.add(StartingNodesFetcher.parseStart(docUri));
+                            }
+                        }
+                    }
+                }
+            } else {
+                throw new RuntimeException("Failed to make query for search term " + environment.getArgument(
+                        "searchTerm") + ", received status " + response.statusCode());
+            }
+        } catch (Throwable e) {
+            throw new RuntimeException("Failed to make query for search term " + environment.getArgument(
+                    "searchTerm") + ".  Search service may be unavailable in your environment.", e);
+        }
+
+        List<TelicentGraphNode> nodes = startFilters.stream()
+                                                    .distinct()
+                                                    .flatMap(n -> dsg.stream(graphFilter, n, Node.ANY, Node.ANY))
+                                                    .map(Quad::getSubject)
+                                                    .distinct()
+                                                    .map(n -> new TelicentGraphNode(n, dsg.prefixes()))
+                                                    .toList();
+        telicentResults.setNodes(nodes);
+        return telicentResults;
+    }
+
+    private void configureSearchApiUrl() {
+        // Get the Search API URL trimming off any trailing slash
+        this.searchApiUrl = AbstractSearchFetcher.findSearchApiUrl();
+        if (this.searchApiUrl.endsWith("/")) {
+            this.searchApiUrl = this.searchApiUrl.substring(0, this.searchApiUrl.length() - 1);
+        }
+        LOGGER.info("Configured Search API URL as {}", this.searchApiUrl);
+    }
+}

--- a/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/fetchers/telicent/graph/StartingNodesFetcher.java
+++ b/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/fetchers/telicent/graph/StartingNodesFetcher.java
@@ -59,7 +59,14 @@ public class StartingNodesFetcher implements DataFetcher<Object> {
         return multiSelect ? nodes : (!nodes.isEmpty() ? nodes.get(0) : null);
     }
 
-    private static boolean usedAsSubjectOrObject(Node n, DatasetGraph dsg, Node graphFilter) {
+    /**
+     * Given a node checks whether it is used as either the subject/object of any quads in the dataset
+     * @param n Node
+     * @param dsg Dataset
+     * @param graphFilter Graph node
+     * @return True if used as a subject/object, false otherwise
+     */
+    public static boolean usedAsSubjectOrObject(Node n, DatasetGraph dsg, Node graphFilter) {
         return dsg.contains(graphFilter, n, Node.ANY, Node.ANY) || dsg.contains(graphFilter, Node.ANY, Node.ANY, n);
     }
 

--- a/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/fetchers/telicent/graph/StartingSearchFetcher.java
+++ b/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/fetchers/telicent/graph/StartingSearchFetcher.java
@@ -33,7 +33,6 @@ public class StartingSearchFetcher extends AbstractSearchFetcher<List<TelicentGr
     }
 
     @Override
-    @SuppressWarnings("unchecked")
     public List<TelicentGraphNode> get(DataFetchingEnvironment environment) {
         TelicentSearchResults results = searchCommon(environment);
         return results.getNodes();

--- a/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/fetchers/telicent/graph/StartingSearchV2Fetcher.java
+++ b/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/fetchers/telicent/graph/StartingSearchV2Fetcher.java
@@ -17,26 +17,25 @@ import graphql.schema.DataFetchingEnvironment;
 import io.telicent.jena.graphql.schemas.telicent.graph.models.TelicentGraphNode;
 import io.telicent.jena.graphql.schemas.telicent.graph.models.TelicentSearchResults;
 
-import java.util.*;
+import java.util.List;
 
 /**
  * A GraphQL {@link DataFetcher} that finds the starting points for a query based upon search terms which are passed on
  * to the Telicent Search REST API to find the matching entities
  */
-public class StartingSearchFetcher extends AbstractSearchFetcher<List<TelicentGraphNode>> {
+public class StartingSearchV2Fetcher extends AbstractSearchFetcher<TelicentSearchResults> {
 
     /**
      * Creates a new fetcher that uses a search query to find nodes of interest
      */
-    public StartingSearchFetcher() {
+    public StartingSearchV2Fetcher() {
 
     }
 
     @Override
     @SuppressWarnings("unchecked")
-    public List<TelicentGraphNode> get(DataFetchingEnvironment environment) {
-        TelicentSearchResults results = searchCommon(environment);
-        return results.getNodes();
+    public TelicentSearchResults get(DataFetchingEnvironment environment) {
+        return searchCommon(environment);
     }
 
 }

--- a/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/fetchers/telicent/graph/StartingSearchWithMetadataFetcher.java
+++ b/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/fetchers/telicent/graph/StartingSearchWithMetadataFetcher.java
@@ -14,21 +14,18 @@ package io.telicent.jena.graphql.fetchers.telicent.graph;
 
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
-import io.telicent.jena.graphql.schemas.telicent.graph.models.TelicentGraphNode;
 import io.telicent.jena.graphql.schemas.telicent.graph.models.TelicentSearchResults;
-
-import java.util.List;
 
 /**
  * A GraphQL {@link DataFetcher} that finds the starting points for a query based upon search terms which are passed on
  * to the Telicent Search REST API to find the matching entities
  */
-public class StartingSearchV2Fetcher extends AbstractSearchFetcher<TelicentSearchResults> {
+public class StartingSearchWithMetadataFetcher extends AbstractSearchFetcher<TelicentSearchResults> {
 
     /**
      * Creates a new fetcher that uses a search query to find nodes of interest
      */
-    public StartingSearchV2Fetcher() {
+    public StartingSearchWithMetadataFetcher() {
 
     }
 

--- a/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/schemas/telicent/graph/TelicentGraphSchema.java
+++ b/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/schemas/telicent/graph/TelicentGraphSchema.java
@@ -57,6 +57,8 @@ public class TelicentGraphSchema {
      * State type
      */
     public static final String TYPE_STATE = "State";
+
+    public static final String TYPE_SEARCH_RESULTS = "SearchResults";
     /**
      * Non-directional relationship type
      */
@@ -65,6 +67,10 @@ public class TelicentGraphSchema {
      * Search query
      */
     public static final String QUERY_SEARCH = "search";
+    /**
+     * Search query version 2
+     */
+    public static final String QUERY_SEARCH_V2 = "searchV2";
     /**
      * Single node query
      */
@@ -97,6 +103,22 @@ public class TelicentGraphSchema {
      * Search term argument used to specify the search term passed onto Telicent Search API
      */
     public static final String ARGUMENT_SEARCH_TERM = "searchTerm";
+    /**
+     * Search type arguments used to specify the type of search used for the Telicent Search API
+     */
+    public static final String ARGUMENT_SEARCH_TYPE = "searchType";
+    /**
+     * Limit argument used to control paging on queries that support it
+     */
+    public static final String ARGUMENT_LIMIT = "limit";
+    /**
+     * Offset argument used to control paging on queries that support it
+     */
+    public static final String ARGUMENT_OFFSET = "offset";
+    /**
+     * Type filter argument used to specify a type filter for the Telicent Search API
+     */
+    public static final String ARGUMENT_TYPE_FILTER = "typeFilter";
     /**
      * Type field
      */
@@ -157,6 +179,7 @@ public class TelicentGraphSchema {
      * Relations field
      */
     public static final String FIELD_RELATIONS = "relations";
+
     /**
      * Extension property used to supply the users authentication token that may be passed on by some
      * {@link graphql.schema.DataFetcher} instances when they need to query other Telicent services

--- a/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/schemas/telicent/graph/TelicentGraphSchema.java
+++ b/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/schemas/telicent/graph/TelicentGraphSchema.java
@@ -72,7 +72,7 @@ public class TelicentGraphSchema {
     /**
      * Search query version 2
      */
-    public static final String QUERY_SEARCH_V2 = "searchV2";
+    public static final String QUERY_SEARCH_WITH_METADATA = "searchWithMetadata";
     /**
      * Single node query
      */

--- a/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/schemas/telicent/graph/TelicentGraphSchema.java
+++ b/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/schemas/telicent/graph/TelicentGraphSchema.java
@@ -57,7 +57,9 @@ public class TelicentGraphSchema {
      * State type
      */
     public static final String TYPE_STATE = "State";
-
+    /**
+     * Search results type
+     */
     public static final String TYPE_SEARCH_RESULTS = "SearchResults";
     /**
      * Non-directional relationship type

--- a/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/schemas/telicent/graph/models/SearchType.java
+++ b/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/schemas/telicent/graph/models/SearchType.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (C) Telicent Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.telicent.jena.graphql.schemas.telicent.graph.models;
+
+/**
+ * Supported search types
+ */
+public enum SearchType {
+    /**
+     * Querystring
+     */
+    QUERY,
+    /**
+     * Term
+     */
+    TERM,
+    /**
+     * Phrase
+     */
+    PHRASE,
+    /**
+     * Wildcard
+     */
+    WILDCARD
+}

--- a/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/schemas/telicent/graph/models/TelicentSearchResults.java
+++ b/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/schemas/telicent/graph/models/TelicentSearchResults.java
@@ -49,17 +49,65 @@ public class TelicentSearchResults {
         this.nodes = nodes;
     }
 
+    /**
+     * Sets the result nodes
+     *
+     * @param nodes Result nodes
+     */
     public void setNodes(List<TelicentGraphNode> nodes) {
         this.nodes.clear();
         this.nodes.addAll(nodes);
     }
 
+    /**
+     * Given a map of raw search results returned by the Telicent Search API convert into the GraphQL model of those
+     * results
+     *
+     * @param map Raw results map
+     * @return Telicent Search Results
+     */
     public static TelicentSearchResults fromMap(Map<String, Object> map) {
         return new TelicentSearchResults((String) map.get("query"),
-                                         SearchType.valueOf(map.get("type").toString().toUpperCase(Locale.ROOT)),
-                                         (Integer) map.get(TelicentGraphSchema.ARGUMENT_LIMIT),
-                                         (Integer) map.get(TelicentGraphSchema.ARGUMENT_OFFSET),
-                                         (Boolean) map.get("maybeMore"), new ArrayList<>());
+                                         parseSearchType(map),
+                                         parseInteger(map, TelicentGraphSchema.ARGUMENT_LIMIT),
+                                         parseInteger(map, TelicentGraphSchema.ARGUMENT_OFFSET),
+                                         parseMaybeMore(map), new ArrayList<>());
+    }
+
+    private static Boolean parseMaybeMore(Map<String, Object> map) {
+        Object rawValue = map.get("maybeMore");
+        if (rawValue == null) {
+            return false;
+        } else if (rawValue instanceof Boolean) {
+            return (Boolean) rawValue;
+        } else if (rawValue instanceof String) {
+            return Boolean.parseBoolean((String) rawValue);
+        } else {
+            return false;
+        }
+    }
+
+    private static Integer parseInteger(Map<String, Object> map, String field) {
+        Object rawValue = map.get(field);
+        if (rawValue == null) {
+            return -1;
+        } else if (rawValue instanceof Integer) {
+            return (Integer) rawValue;
+        } else if (rawValue instanceof String) {
+            try {
+                return Integer.parseInt((String) rawValue);
+            } catch (NumberFormatException e) {
+                return -1;
+            }
+        } else {
+            return -1;
+        }
+    }
+
+    private static SearchType parseSearchType(Map<String, Object> map) {
+        Object rawSearchType = map.get("type");
+        return rawSearchType != null ? SearchType.valueOf(rawSearchType.toString().toUpperCase(Locale.ROOT)) :
+               SearchType.QUERY;
     }
 
     /**

--- a/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/schemas/telicent/graph/models/TelicentSearchResults.java
+++ b/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/schemas/telicent/graph/models/TelicentSearchResults.java
@@ -1,0 +1,125 @@
+/**
+ * Copyright (C) Telicent Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.telicent.jena.graphql.schemas.telicent.graph.models;
+
+import io.telicent.jena.graphql.schemas.telicent.graph.TelicentGraphSchema;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Represents a set of Telicent Search results, includes metadata about the results as well as the results themselves
+ */
+public class TelicentSearchResults {
+    private final int limit, offset;
+    private final boolean maybeMore;
+    private final String searchTerm;
+    private final SearchType searchType;
+    private final List<TelicentGraphNode> nodes;
+
+    /**
+     * Creates a new set of search results
+     *
+     * @param searchTerm Search Term
+     * @param searchType Search Type
+     * @param limit      Limit
+     * @param offset     Offset
+     * @param maybeMore  Boolean indicating whether more results may be available
+     * @param nodes      Result nodes
+     */
+    public TelicentSearchResults(String searchTerm, SearchType searchType, int limit, int offset, boolean maybeMore,
+                                 List<TelicentGraphNode> nodes) {
+        this.limit = limit;
+        this.offset = offset;
+        this.maybeMore = maybeMore;
+        this.searchTerm = searchTerm;
+        this.searchType = searchType;
+        this.nodes = nodes;
+    }
+
+    public void setNodes(List<TelicentGraphNode> nodes) {
+        this.nodes.clear();
+        this.nodes.addAll(nodes);
+    }
+
+    public static TelicentSearchResults fromMap(Map<String, Object> map) {
+        return new TelicentSearchResults((String) map.get("query"),
+                                         SearchType.valueOf(map.get("type").toString().toUpperCase(Locale.ROOT)),
+                                         (Integer) map.get(TelicentGraphSchema.ARGUMENT_LIMIT),
+                                         (Integer) map.get(TelicentGraphSchema.ARGUMENT_OFFSET),
+                                         (Boolean) map.get("maybeMore"), new ArrayList<>());
+    }
+
+    /**
+     * Gets the limit used for this search query
+     *
+     * @return Limit
+     */
+    public int getLimit() {
+        return limit;
+    }
+
+    /**
+     * Gets the offset used for this search query
+     *
+     * @return Offset
+     */
+    public int getOffset() {
+        return offset;
+    }
+
+    /**
+     * Gets whether asking for a new page of results may offer further results
+     * <p>
+     * As the name suggests this is not a guarantee, it may return {@code true} when there actually aren't any further
+     * results available, or return {@code false} when more results may be available in the future.  This is due to the
+     * lazy evaluation of search queries behind the scenes and the fact that the search index, like all Telicent Smart
+     * Caches, exhibits eventual consistency so may not be up to date with the state of the graph database (or vice
+     * versa).
+     * </p>
+     *
+     * @return True if maybe more results, false otherwise
+     */
+    public boolean isMaybeMore() {
+        return maybeMore;
+    }
+
+    /**
+     * Gets the search term that was used to produce these search results
+     *
+     * @return Search Term
+     */
+    public String getSearchTerm() {
+        return searchTerm;
+    }
+
+    /**
+     * Gets the search type that was used to produce these search results
+     *
+     * @return Search Type
+     */
+    public SearchType getSearchType() {
+        return searchType;
+    }
+
+    /**
+     * Gets the nodes that the search identified
+     *
+     * @return Nodes
+     */
+    public List<TelicentGraphNode> getNodes() {
+        return nodes;
+    }
+}

--- a/telicent-graph-schema/src/main/resources/io/telicent/jena/graphql/schemas/telicent/graph/ies.graphqls
+++ b/telicent-graph-schema/src/main/resources/io/telicent/jena/graphql/schemas/telicent/graph/ies.graphqls
@@ -65,8 +65,8 @@ type Query {
         limit: Int
         offset: Int
         typeFilter: String
-    ): [Node] @deprecated(reason: "Use `searchV2` which offers richer response schema")
-    searchV2(
+    ): [Node] @deprecated(reason: "Use `searchWithMetadata` which offers richer response schema")
+    searchWithMetadata(
         graph: String
         searchTerm: String!
         searchType: SearchType

--- a/telicent-graph-schema/src/main/resources/io/telicent/jena/graphql/schemas/telicent/graph/ies.graphqls
+++ b/telicent-graph-schema/src/main/resources/io/telicent/jena/graphql/schemas/telicent/graph/ies.graphqls
@@ -41,13 +41,39 @@ type NonDirectionalRel {
     entity: Node!
 }
 
+enum SearchType {
+    QUERY,
+    TERM,
+    PHRASE,
+    WILDCARD
+}
+
+type SearchResults {
+    searchTerm: String!
+    searchType: SearchType!
+    limit: Int!
+    offset: Int!
+    maybeMore: Boolean!
+    nodes: [Node]
+}
+
 type Query {
     search(
         graph: String
         searchTerm: String!
+        searchType: SearchType
         limit: Int
         offset: Int
-    ): [Node]
+        typeFilter: String
+    ): [Node] @deprecated(reason: "Use `searchV2` which offers richer response schema")
+    searchV2(
+        graph: String
+        searchTerm: String!
+        searchType: SearchType
+        limit: Int
+        offset: Int
+        typeFilter: String
+    ): SearchResults
     getAllEntities(graph: String): [Node]
     states(uri: String!): [State]!
     node(graph: String, uri: String!): Node

--- a/telicent-graph-schema/src/test/java/io/telicent/jena/graphql/fetchers/telicent/graph/TestAbstractSearchFetcher.java
+++ b/telicent-graph-schema/src/test/java/io/telicent/jena/graphql/fetchers/telicent/graph/TestAbstractSearchFetcher.java
@@ -1,0 +1,100 @@
+/**
+ * Copyright (C) Telicent Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.telicent.jena.graphql.fetchers.telicent.graph;
+
+import graphql.schema.DataFetchingEnvironment;
+import graphql.schema.DataFetchingEnvironmentImpl;
+import io.telicent.jena.graphql.execution.telicent.graph.TelicentExecutionContext;
+import io.telicent.jena.graphql.schemas.telicent.graph.TelicentGraphSchema;
+import io.telicent.jena.graphql.schemas.telicent.graph.models.SearchType;
+import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.jena.sparql.core.DatasetGraph;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+public class TestAbstractSearchFetcher {
+
+    private final DatasetGraph dsg = TestStartingSearchFetcher.createPagedSearchTestDataset();
+
+    @Test
+    public void givenMinimalArguments_whenFormingSearchUrl_thenMinimalUrl() {
+        // Given
+        TelicentExecutionContext context = new TelicentExecutionContext(dsg, "");
+        DataFetchingEnvironment environment = DataFetchingEnvironmentImpl.newDataFetchingEnvironment()
+                                                                         .localContext(context)
+                                                                         .arguments(
+                                                                                 Map.of(TelicentGraphSchema.ARGUMENT_SEARCH_TERM,
+                                                                                        "test"))
+                                                                         .build();
+
+        // When
+        URI searchUrl =
+                AbstractSearchFetcher.buildSearchApiRequestUri(AbstractSearchFetcher.DEFAULT_SEARCH_API_URL, "test",
+                                                               environment);
+
+        // Then
+        Assert.assertEquals(searchUrl.getPath(), "/documents");
+        Assert.assertEquals(searchUrl.getQuery(), "query=test");
+    }
+
+    @DataProvider(name = "searchArguments")
+    public Object[][] searchArguments() {
+        return new Object[][] {
+                { Map.of(TelicentGraphSchema.ARGUMENT_SEARCH_TYPE, SearchType.TERM), Map.of("type", "term") },
+                {
+                        Map.of(TelicentGraphSchema.ARGUMENT_LIMIT, 10, TelicentGraphSchema.ARGUMENT_OFFSET, 100),
+                        Map.of(TelicentGraphSchema.ARGUMENT_LIMIT, "1", TelicentGraphSchema.ARGUMENT_OFFSET, "100")
+                },
+                {
+                        Map.of(TelicentGraphSchema.ARGUMENT_LIMIT, 100),
+                        Map.of(TelicentGraphSchema.ARGUMENT_LIMIT, "100")
+                },
+                {
+                        Map.of(TelicentGraphSchema.ARGUMENT_TYPE_FILTER, "Person"),
+                        Map.of("type-filter",
+                               Base64.encodeBase64URLSafeString("Person".getBytes(StandardCharsets.UTF_8)),
+                               "is-type-filter-base64", "true")
+                }
+        };
+    }
+
+    @Test(dataProvider = "searchArguments")
+    public void givenValidArguments_whenFormingSearchUrl_thenReflectedInUrl(Map<String, Object> arguments,
+                                                                            Map<String, String> expectedQuerystringParameters) {
+        // Given
+        TelicentExecutionContext context = new TelicentExecutionContext(dsg, "");
+        DataFetchingEnvironment environment = DataFetchingEnvironmentImpl.newDataFetchingEnvironment()
+                                                                         .localContext(context)
+                                                                         .arguments(arguments)
+                                                                         .build();
+
+        // When
+        URI searchUrl = AbstractSearchFetcher.buildSearchApiRequestUri("https://some-deployment/api/search", "test",
+                                                                       environment);
+
+        // Then
+        Assert.assertEquals(searchUrl.getPath(), "/api/search/documents");
+        Assert.assertTrue(StringUtils.contains(searchUrl.getQuery(), "query=test"));
+        for (Map.Entry<String, String> entry : expectedQuerystringParameters.entrySet()) {
+            Assert.assertTrue(StringUtils.contains(searchUrl.getQuery(),
+                                                   String.format("&%s=%s", entry.getKey(), entry.getValue())),
+                              "Expected querystring parameter " + entry.getKey() + " was not present in generated URL");
+        }
+    }
+}

--- a/telicent-graph-schema/src/test/java/io/telicent/jena/graphql/fetchers/telicent/graph/TestAllEntitiesFetcher.java
+++ b/telicent-graph-schema/src/test/java/io/telicent/jena/graphql/fetchers/telicent/graph/TestAllEntitiesFetcher.java
@@ -12,7 +12,6 @@
  */
 package io.telicent.jena.graphql.fetchers.telicent.graph;
 
-import graphql.Assert;
 import graphql.schema.DataFetchingEnvironment;
 import graphql.schema.DataFetchingEnvironmentImpl;
 import io.telicent.jena.graphql.execution.telicent.graph.TelicentExecutionContext;
@@ -21,6 +20,7 @@ import org.apache.jena.sparql.core.DatasetGraph;
 import org.apache.jena.sparql.core.DatasetGraphFactory;
 import org.apache.jena.sparql.core.Quad;
 import org.apache.jena.vocabulary.RDF;
+import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import java.util.List;

--- a/telicent-graph-schema/src/test/java/io/telicent/jena/graphql/fetchers/telicent/graph/TestStartingSearchFetcher.java
+++ b/telicent-graph-schema/src/test/java/io/telicent/jena/graphql/fetchers/telicent/graph/TestStartingSearchFetcher.java
@@ -14,21 +14,23 @@ package io.telicent.jena.graphql.fetchers.telicent.graph;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.tomakehurst.wiremock.WireMockServer;
-import graphql.Assert;
 import graphql.schema.DataFetchingEnvironment;
 import graphql.schema.DataFetchingEnvironmentImpl;
 import io.telicent.jena.graphql.execution.telicent.graph.TelicentExecutionContext;
 import io.telicent.jena.graphql.schemas.telicent.graph.models.TelicentGraphNode;
+import io.telicent.jena.graphql.schemas.telicent.graph.models.TelicentSearchResults;
 import org.apache.jena.sparql.core.DatasetGraph;
 import org.apache.jena.sparql.core.DatasetGraphFactory;
 import org.apache.jena.sparql.core.Quad;
 import org.apache.jena.vocabulary.RDF;
+import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterTest;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -38,7 +40,7 @@ import static java.util.Collections.emptyMap;
 import static org.apache.jena.graph.NodeFactory.*;
 
 public class TestStartingSearchFetcher {
-    private static ObjectMapper MAPPER = new ObjectMapper();
+    private static final ObjectMapper MAPPER = new ObjectMapper();
 
     private static WireMockServer WIRE_MOCK_SERVER;
 
@@ -61,18 +63,19 @@ public class TestStartingSearchFetcher {
 
     // NOTE: All other fetchers use specific exceptions, worth a revisit?
     @Test(expectedExceptions = RuntimeException.class)
-    public void givenNoSearchTerm_whenUsingSearchFetcher_thenErrorIsThrown()  {
+    public void givenNoSearchTerm_whenUsingSearchFetcher_thenErrorIsThrown() {
         // given
         StartingSearchFetcher fetcher = new StartingSearchFetcher();
-        DatasetGraph dsg  = DatasetGraphFactory.create();
-        dsg.add(new Quad(createLiteralString("graph"), createBlankNode("subject"), RDF.type.asNode(), createLiteralString("object")));
-        dsg.add(new Quad(createLiteralString("graph"), createBlankNode("subject"), RDF.type.asNode(), createBlankNode("object")));
-        dsg.add(new Quad(createLiteralString("graph"), createBlankNode("subject"), RDF.type.asNode(), createURI("object")));
+        DatasetGraph dsg = DatasetGraphFactory.create();
+        dsg.add(new Quad(createLiteralString("graph"), createBlankNode("subject"), RDF.type.asNode(),
+                         createLiteralString("object")));
+        dsg.add(new Quad(createLiteralString("graph"), createBlankNode("subject"), RDF.type.asNode(),
+                         createBlankNode("object")));
+        dsg.add(new Quad(createLiteralString("graph"), createBlankNode("subject"), RDF.type.asNode(),
+                         createURI("object")));
         TelicentExecutionContext context = new TelicentExecutionContext(dsg, "");
-        DataFetchingEnvironment environment = DataFetchingEnvironmentImpl
-                .newDataFetchingEnvironment()
-                .localContext(context)
-                .build();
+        DataFetchingEnvironment environment =
+                DataFetchingEnvironmentImpl.newDataFetchingEnvironment().localContext(context).build();
         // when
         // then
         fetcher.get(environment);
@@ -81,20 +84,21 @@ public class TestStartingSearchFetcher {
     @Test(expectedExceptions = RuntimeException.class)
     public void givenBadSearchResponse_whenUsingSearchFetcher_thenErrorIsThrown() {
         // given
-        WIRE_MOCK_SERVER.stubFor(get(urlEqualTo("/documents?query=test"))
-                                         .willReturn(notFound()));
+        WIRE_MOCK_SERVER.stubFor(get(urlEqualTo("/documents?query=test")).willReturn(notFound()));
 
         StartingSearchFetcher fetcher = new StartingSearchFetcher();
-        DatasetGraph dsg  = DatasetGraphFactory.create();
-        dsg.add(new Quad(createLiteralString("graph"), createBlankNode("subject"), RDF.type.asNode(), createLiteralString("object")));
-        dsg.add(new Quad(createLiteralString("graph"), createBlankNode("subject"), RDF.type.asNode(), createBlankNode("object")));
-        dsg.add(new Quad(createLiteralString("graph"), createBlankNode("subject"), RDF.type.asNode(), createURI("object")));
+        DatasetGraph dsg = DatasetGraphFactory.create();
+        dsg.add(new Quad(createLiteralString("graph"), createBlankNode("subject"), RDF.type.asNode(),
+                         createLiteralString("object")));
+        dsg.add(new Quad(createLiteralString("graph"), createBlankNode("subject"), RDF.type.asNode(),
+                         createBlankNode("object")));
+        dsg.add(new Quad(createLiteralString("graph"), createBlankNode("subject"), RDF.type.asNode(),
+                         createURI("object")));
         TelicentExecutionContext context = new TelicentExecutionContext(dsg, "authtoken");
-        DataFetchingEnvironment environment = DataFetchingEnvironmentImpl
-                .newDataFetchingEnvironment()
-                .localContext(context)
-                .arguments(Map.of("searchTerm","test"))
-                .build();
+        DataFetchingEnvironment environment = DataFetchingEnvironmentImpl.newDataFetchingEnvironment()
+                                                                         .localContext(context)
+                                                                         .arguments(Map.of("searchTerm", "test"))
+                                                                         .build();
         // when
         // then
         fetcher.get(environment);
@@ -104,21 +108,21 @@ public class TestStartingSearchFetcher {
     public void givenEmptySearchResponse_whenUsingSearchFetcher_thenSuccess() {
         // given
         System.setProperty("SEARCH_API_URL", "http://localhost:8181/");
-        WIRE_MOCK_SERVER.stubFor(get(urlEqualTo("/documents?query=test"))
-                                         .willReturn(ok().withBody("{}")
-                                         ));
+        WIRE_MOCK_SERVER.stubFor(get(urlEqualTo("/documents?query=test")).willReturn(ok().withBody("{}")));
 
         StartingSearchFetcher fetcher = new StartingSearchFetcher();
-        DatasetGraph dsg  = DatasetGraphFactory.create();
-        dsg.add(new Quad(createLiteralString("graph"), createBlankNode("subject"), RDF.type.asNode(), createLiteralString("object")));
-        dsg.add(new Quad(createLiteralString("graph"), createBlankNode("subject"), RDF.type.asNode(), createBlankNode("object")));
-        dsg.add(new Quad(createLiteralString("graph"), createBlankNode("subject"), RDF.type.asNode(), createURI("object")));
+        DatasetGraph dsg = DatasetGraphFactory.create();
+        dsg.add(new Quad(createLiteralString("graph"), createBlankNode("subject"), RDF.type.asNode(),
+                         createLiteralString("object")));
+        dsg.add(new Quad(createLiteralString("graph"), createBlankNode("subject"), RDF.type.asNode(),
+                         createBlankNode("object")));
+        dsg.add(new Quad(createLiteralString("graph"), createBlankNode("subject"), RDF.type.asNode(),
+                         createURI("object")));
         TelicentExecutionContext context = new TelicentExecutionContext(dsg, "");
-        DataFetchingEnvironment environment = DataFetchingEnvironmentImpl
-                .newDataFetchingEnvironment()
-                .localContext(context)
-                .arguments(Map.of("searchTerm","test"))
-                .build();
+        DataFetchingEnvironment environment = DataFetchingEnvironmentImpl.newDataFetchingEnvironment()
+                                                                         .localContext(context)
+                                                                         .arguments(Map.of("searchTerm", "test"))
+                                                                         .build();
         // when
         List<TelicentGraphNode> actualList = fetcher.get(environment);
         // then
@@ -128,22 +132,26 @@ public class TestStartingSearchFetcher {
     }
 
     @Test
-    public void givenSearchResponse_whenUsingSearchFetcher_thenSuccess() throws IOException  {
+    public void givenSearchResponse_whenUsingSearchFetcher_thenSuccess() throws IOException {
         // given
-        Map<String, List<Map<String,Object>>> returnedData = Map.of("results", List.of(Map.of("document", Map.of("uri", "subject")), emptyMap(), Map.of("document", Map.of("something", "else"))));
-        WIRE_MOCK_SERVER.stubFor(get(urlEqualTo("/documents?query=test"))
-                                         .willReturn(ok().withBody(MAPPER.writeValueAsString(returnedData))
-                                         ));
+        Map<String, List<Map<String, Object>>> returnedData = Map.of("results", List.of(Map.of("document", Map.of("uri",
+                                                                                                                  "subject")),
+                                                                                        emptyMap(), Map.of("document",
+                                                                                                           Map.of("something",
+                                                                                                                  "else"))));
+        WIRE_MOCK_SERVER.stubFor(get(urlEqualTo("/documents?query=test")).willReturn(
+                ok().withBody(MAPPER.writeValueAsString(returnedData))));
 
         StartingSearchFetcher fetcher = new StartingSearchFetcher();
-        DatasetGraph dsg  = DatasetGraphFactory.create();
+        DatasetGraph dsg = DatasetGraphFactory.create();
         dsg.add(new Quad(createURI("graph"), createURI("subject"), RDF.type.asNode(), createLiteralString("object1")));
         TelicentExecutionContext context = new TelicentExecutionContext(dsg, "");
-        DataFetchingEnvironment environment = DataFetchingEnvironmentImpl
-                .newDataFetchingEnvironment()
-                .localContext(context)
-                .arguments(Map.of("graph", "graph", "searchTerm","test"))
-                .build();
+        DataFetchingEnvironment environment = DataFetchingEnvironmentImpl.newDataFetchingEnvironment()
+                                                                         .localContext(context)
+                                                                         .arguments(
+                                                                                 Map.of("graph", "graph", "searchTerm",
+                                                                                        "test"))
+                                                                         .build();
         // when
         List<TelicentGraphNode> actualList = fetcher.get(environment);
         // then
@@ -157,30 +165,45 @@ public class TestStartingSearchFetcher {
                        Map.of("document", Map.of("uri", "subject2", "something", "else")));
     }
 
-    private static DatasetGraph createPagedSearchTestDataset() {
-        DatasetGraph dsg  = DatasetGraphFactory.create();
+    private static Map<String, Object> createSearchResults(List<Map<?, ?>> resultItems, int offset, int limit) {
+        //@formatter:off
+        return Map.of("results",
+                        offset - 1 >= resultItems.size() ?
+                                 Collections.emptyList() :
+                                 resultItems.subList(offset - 1, Math.min(offset + limit, resultItems.size())),
+                      "query", "test",
+                      "type", "query",
+                      "limit", limit,
+                      "offset", offset,
+                      "maybeMore", offset + limit - 1 < resultItems.size() - 1);
+        //@formatter:on
+    }
+
+    public static DatasetGraph createPagedSearchTestDataset() {
+        DatasetGraph dsg = DatasetGraphFactory.create();
         dsg.add(new Quad(createURI("graph"), createURI("subject"), RDF.type.asNode(), createLiteralString("object1")));
         dsg.add(new Quad(createURI("graph"), createURI("subject2"), RDF.type.asNode(), createLiteralString("object2")));
         return dsg;
     }
 
     @Test
-    public void givenPagedSearchResponse_whenUsingSearchFetcherWithLimit_thenSuccess_andCorrectResults() throws IOException  {
+    public void givenPagedSearchResponse_whenUsingSearchFetcherWithLimit_thenSuccess_andCorrectResults() throws
+            IOException {
         // given
         List<Map<?, ?>> resultItems = createPagedResultDocuments();
-        Map<String, List<?>> pagedData = Map.of("results", resultItems.subList(0, 1));
-        WIRE_MOCK_SERVER.stubFor(get(urlEqualTo("/documents?query=test&limit=1"))
-                                         .willReturn(ok().withBody(MAPPER.writeValueAsString(pagedData))
-                                         ));
+        Map<String, Object> pagedData = createSearchResults(resultItems, 1, 1);
+        WIRE_MOCK_SERVER.stubFor(get(urlEqualTo("/documents?query=test&limit=1")).willReturn(
+                ok().withBody(MAPPER.writeValueAsString(pagedData))));
 
         StartingSearchFetcher fetcher = new StartingSearchFetcher();
         DatasetGraph dsg = createPagedSearchTestDataset();
         TelicentExecutionContext context = new TelicentExecutionContext(dsg, "");
-        DataFetchingEnvironment environment = DataFetchingEnvironmentImpl
-                .newDataFetchingEnvironment()
-                .localContext(context)
-                .arguments(Map.of("graph", "graph", "searchTerm","test", "limit", 1))
-                .build();
+        DataFetchingEnvironment environment = DataFetchingEnvironmentImpl.newDataFetchingEnvironment()
+                                                                         .localContext(context)
+                                                                         .arguments(
+                                                                                 Map.of("graph", "graph", "searchTerm",
+                                                                                        "test", "limit", 1))
+                                                                         .build();
         // when
         List<TelicentGraphNode> actualList = fetcher.get(environment);
         // then
@@ -192,22 +215,54 @@ public class TestStartingSearchFetcher {
     }
 
     @Test
-    public void givenPagedSearchResponse_whenUsingSearchFetcherWithOffset_thenSuccess_andCorrectResults() throws IOException  {
+    public void givenPagedSearchResponse_whenUsingSearchV2FetcherWithLimit_thenSuccess_andCorrectMetadataAndResults() throws
+            IOException {
         // given
         List<Map<?, ?>> resultItems = createPagedResultDocuments();
-        Map<String, List<?>> pagedData = Map.of("results", resultItems.subList(1, resultItems.size()));
-        WIRE_MOCK_SERVER.stubFor(get(urlEqualTo("/documents?query=test&offset=2"))
-                                         .willReturn(ok().withBody(MAPPER.writeValueAsString(pagedData))
-                                         ));
+        Map<String, Object> pagedData = createSearchResults(resultItems, 1, 1);
+        WIRE_MOCK_SERVER.stubFor(get(urlEqualTo("/documents?query=test&limit=1")).willReturn(
+                ok().withBody(MAPPER.writeValueAsString(pagedData))));
+
+        StartingSearchV2Fetcher fetcher = new StartingSearchV2Fetcher();
+        DatasetGraph dsg = createPagedSearchTestDataset();
+        TelicentExecutionContext context = new TelicentExecutionContext(dsg, "");
+        DataFetchingEnvironment environment = DataFetchingEnvironmentImpl.newDataFetchingEnvironment()
+                                                                         .localContext(context)
+                                                                         .arguments(
+                                                                                 Map.of("graph", "graph", "searchTerm",
+                                                                                        "test", "limit", 1))
+                                                                         .build();
+        // when
+        TelicentSearchResults results = fetcher.get(environment);
+        // then
+        Assert.assertNotNull(results);
+        Assert.assertFalse(results.getNodes().isEmpty());
+        WIRE_MOCK_SERVER.verify(getRequestedFor(urlEqualTo("/documents?query=test&limit=1")));
+        // and
+        Assert.assertEquals(results.getLimit(), 1);
+        Assert.assertEquals(results.getOffset(), 1);
+        Assert.assertTrue(results.isMaybeMore());
+        Assert.assertTrue(results.getNodes().stream().anyMatch(n -> n.getUri().equals("subject")));
+    }
+
+    @Test
+    public void givenPagedSearchResponse_whenUsingSearchFetcherWithOffset_thenSuccess_andCorrectResults() throws
+            IOException {
+        // given
+        List<Map<?, ?>> resultItems = createPagedResultDocuments();
+        Map<String, Object> pagedData = createSearchResults(resultItems, 2, resultItems.size());
+        WIRE_MOCK_SERVER.stubFor(get(urlEqualTo("/documents?query=test&offset=2")).willReturn(
+                ok().withBody(MAPPER.writeValueAsString(pagedData))));
 
         StartingSearchFetcher fetcher = new StartingSearchFetcher();
         DatasetGraph dsg = createPagedSearchTestDataset();
         TelicentExecutionContext context = new TelicentExecutionContext(dsg, "");
-        DataFetchingEnvironment environment = DataFetchingEnvironmentImpl
-                .newDataFetchingEnvironment()
-                .localContext(context)
-                .arguments(Map.of("graph", "graph", "searchTerm","test", "offset", 2))
-                .build();
+        DataFetchingEnvironment environment = DataFetchingEnvironmentImpl.newDataFetchingEnvironment()
+                                                                         .localContext(context)
+                                                                         .arguments(
+                                                                                 Map.of("graph", "graph", "searchTerm",
+                                                                                        "test", "offset", 2))
+                                                                         .build();
         // when
         List<TelicentGraphNode> actualList = fetcher.get(environment);
         // then
@@ -219,57 +274,121 @@ public class TestStartingSearchFetcher {
     }
 
     @Test
-    public void givenPagedSearchResponse_whenUsingSearchFetcherWithLimitAndOffset_thenNoResults() throws IOException  {
+    public void givenPagedSearchResponse_whenUsingSearchFetcherV2WithOffset_thenSuccess_andCorrectMetadataAndResults() throws
+            IOException {
         // given
         List<Map<?, ?>> resultItems = createPagedResultDocuments();
-        Map<String, List<?>> pagedData = Map.of("results", resultItems.subList(1, 2));
-        WIRE_MOCK_SERVER.stubFor(get(urlEqualTo("/documents?query=test&limit=1&offset=2"))
-                                         .willReturn(ok().withBody(MAPPER.writeValueAsString(pagedData))
-                                         ));
+        Map<String, Object> pagedData = createSearchResults(resultItems, 2, resultItems.size());
+        WIRE_MOCK_SERVER.stubFor(get(urlEqualTo("/documents?query=test&offset=2")).willReturn(
+                ok().withBody(MAPPER.writeValueAsString(pagedData))));
+
+        StartingSearchV2Fetcher fetcher = new StartingSearchV2Fetcher();
+        DatasetGraph dsg = createPagedSearchTestDataset();
+        TelicentExecutionContext context = new TelicentExecutionContext(dsg, "");
+        DataFetchingEnvironment environment = DataFetchingEnvironmentImpl.newDataFetchingEnvironment()
+                                                                         .localContext(context)
+                                                                         .arguments(
+                                                                                 Map.of("graph", "graph", "searchTerm",
+                                                                                        "test", "offset", 2))
+                                                                         .build();
+        // when
+        TelicentSearchResults results = fetcher.get(environment);
+        // then
+        Assert.assertNotNull(results);
+        Assert.assertFalse(results.getNodes().isEmpty());
+        WIRE_MOCK_SERVER.verify(getRequestedFor(urlEqualTo("/documents?query=test&offset=2")));
+        // and
+        Assert.assertEquals(results.getLimit(), 3);
+        Assert.assertEquals(results.getOffset(), 2);
+        Assert.assertFalse(results.isMaybeMore());
+        Assert.assertTrue(results.getNodes().stream().anyMatch(n -> n.getUri().equals("subject2")));
+    }
+
+    @Test
+    public void givenPagedSearchResponse_whenUsingSearchFetcherWithLimitAndOffset_thenNoResults() throws IOException {
+        // given
+        List<Map<?, ?>> resultItems = createPagedResultDocuments();
+        Map<String, Object> pagedData = createSearchResults(resultItems, 4, 1);
+        WIRE_MOCK_SERVER.stubFor(get(urlEqualTo("/documents?query=test&limit=1&offset=4")).willReturn(
+                ok().withBody(MAPPER.writeValueAsString(pagedData))));
 
         StartingSearchFetcher fetcher = new StartingSearchFetcher();
         DatasetGraph dsg = createPagedSearchTestDataset();
         TelicentExecutionContext context = new TelicentExecutionContext(dsg, "");
-        DataFetchingEnvironment environment = DataFetchingEnvironmentImpl
-                .newDataFetchingEnvironment()
-                .localContext(context)
-                .arguments(Map.of("graph", "graph", "searchTerm","test", "offset", 2, "limit", 1))
-                .build();
+        DataFetchingEnvironment environment = DataFetchingEnvironmentImpl.newDataFetchingEnvironment()
+                                                                         .localContext(context)
+                                                                         .arguments(
+                                                                                 Map.of("graph", "graph", "searchTerm",
+                                                                                        "test", "offset", 4, "limit",
+                                                                                        1))
+                                                                         .build();
         // when
         List<TelicentGraphNode> actualList = fetcher.get(environment);
         // then
         Assert.assertNotNull(actualList);
         Assert.assertTrue(actualList.isEmpty());
-        WIRE_MOCK_SERVER.verify(getRequestedFor(urlEqualTo("/documents?query=test&limit=1&offset=2")));
+        WIRE_MOCK_SERVER.verify(getRequestedFor(urlEqualTo("/documents?query=test&limit=1&offset=4")));
+    }
+
+    @Test
+    public void givenPagedSearchResponse_whenUsingSearchFetcherV2WithLimitAndOffset_thenMetadataAndNoResults() throws
+            IOException {
+        // given
+        List<Map<?, ?>> resultItems = createPagedResultDocuments();
+        Map<String, Object> pagedData = createSearchResults(resultItems, 4, 1);
+        WIRE_MOCK_SERVER.stubFor(get(urlEqualTo("/documents?query=test&limit=1&offset=4")).willReturn(
+                ok().withBody(MAPPER.writeValueAsString(pagedData))));
+
+        StartingSearchV2Fetcher fetcher = new StartingSearchV2Fetcher();
+        DatasetGraph dsg = createPagedSearchTestDataset();
+        TelicentExecutionContext context = new TelicentExecutionContext(dsg, "");
+        DataFetchingEnvironment environment = DataFetchingEnvironmentImpl.newDataFetchingEnvironment()
+                                                                         .localContext(context)
+                                                                         .arguments(
+                                                                                 Map.of("graph", "graph", "searchTerm",
+                                                                                        "test", "offset", 4, "limit",
+                                                                                        1))
+                                                                         .build();
+        // when
+        TelicentSearchResults results = fetcher.get(environment);
+        // then
+        Assert.assertNotNull(results);
+        Assert.assertEquals(results.getLimit(), 1);
+        Assert.assertEquals(results.getOffset(), 4);
+        Assert.assertFalse(results.isMaybeMore());
+        Assert.assertTrue(results.getNodes().isEmpty());
+        WIRE_MOCK_SERVER.verify(getRequestedFor(urlEqualTo("/documents?query=test&limit=1&offset=4")));
     }
 
     @Test(expectedExceptions = RuntimeException.class)
-    public void givenInvalidLimit_whenUsingSearchFetcher_thenErrorIsThrown()  {
+    public void givenInvalidLimit_whenUsingSearchFetcher_thenErrorIsThrown() {
         // given
         StartingSearchFetcher fetcher = new StartingSearchFetcher();
         DatasetGraph dsg = createPagedSearchTestDataset();
         TelicentExecutionContext context = new TelicentExecutionContext(dsg, "");
-        DataFetchingEnvironment environment = DataFetchingEnvironmentImpl
-                .newDataFetchingEnvironment()
-                .localContext(context)
-                .arguments(Map.of("searchTerm", "test", "limit", "foo"))
-                .build();
+        DataFetchingEnvironment environment = DataFetchingEnvironmentImpl.newDataFetchingEnvironment()
+                                                                         .localContext(context)
+                                                                         .arguments(
+                                                                                 Map.of("searchTerm", "test", "limit",
+                                                                                        "foo"))
+                                                                         .build();
         // when
         // then
         fetcher.get(environment);
     }
 
     @Test(expectedExceptions = RuntimeException.class)
-    public void givenInvalidOffset_whenUsingSearchFetcher_thenErrorIsThrown()  {
+    public void givenInvalidOffset_whenUsingSearchFetcher_thenErrorIsThrown() {
         // given
         StartingSearchFetcher fetcher = new StartingSearchFetcher();
         DatasetGraph dsg = createPagedSearchTestDataset();
         TelicentExecutionContext context = new TelicentExecutionContext(dsg, "");
-        DataFetchingEnvironment environment = DataFetchingEnvironmentImpl
-                .newDataFetchingEnvironment()
-                .localContext(context)
-                .arguments(Map.of("searchTerm", "test", "offset", "foo"))
-                .build();
+        DataFetchingEnvironment environment = DataFetchingEnvironmentImpl.newDataFetchingEnvironment()
+                                                                         .localContext(context)
+                                                                         .arguments(
+                                                                                 Map.of("searchTerm", "test", "offset",
+                                                                                        "foo"))
+                                                                         .build();
         // when
         // then
         fetcher.get(environment);

--- a/telicent-graph-schema/src/test/java/io/telicent/jena/graphql/fetchers/telicent/graph/TestStartingSearchFetcher.java
+++ b/telicent-graph-schema/src/test/java/io/telicent/jena/graphql/fetchers/telicent/graph/TestStartingSearchFetcher.java
@@ -215,7 +215,7 @@ public class TestStartingSearchFetcher {
     }
 
     @Test
-    public void givenPagedSearchResponse_whenUsingSearchV2FetcherWithLimit_thenSuccess_andCorrectMetadataAndResults() throws
+    public void givenPagedSearchResponse_whenUsingSearchWithMetadataFetcherWithLimit_thenSuccess_andCorrectMetadataAndResults() throws
             IOException {
         // given
         List<Map<?, ?>> resultItems = createPagedResultDocuments();
@@ -223,7 +223,7 @@ public class TestStartingSearchFetcher {
         WIRE_MOCK_SERVER.stubFor(get(urlEqualTo("/documents?query=test&limit=1")).willReturn(
                 ok().withBody(MAPPER.writeValueAsString(pagedData))));
 
-        StartingSearchV2Fetcher fetcher = new StartingSearchV2Fetcher();
+        StartingSearchWithMetadataFetcher fetcher = new StartingSearchWithMetadataFetcher();
         DatasetGraph dsg = createPagedSearchTestDataset();
         TelicentExecutionContext context = new TelicentExecutionContext(dsg, "");
         DataFetchingEnvironment environment = DataFetchingEnvironmentImpl.newDataFetchingEnvironment()
@@ -274,7 +274,7 @@ public class TestStartingSearchFetcher {
     }
 
     @Test
-    public void givenPagedSearchResponse_whenUsingSearchFetcherV2WithOffset_thenSuccess_andCorrectMetadataAndResults() throws
+    public void givenPagedSearchResponse_whenUsingSearchWithMetadataFetcherWithOffset_thenSuccess_andCorrectMetadataAndResults() throws
             IOException {
         // given
         List<Map<?, ?>> resultItems = createPagedResultDocuments();
@@ -282,7 +282,7 @@ public class TestStartingSearchFetcher {
         WIRE_MOCK_SERVER.stubFor(get(urlEqualTo("/documents?query=test&offset=2")).willReturn(
                 ok().withBody(MAPPER.writeValueAsString(pagedData))));
 
-        StartingSearchV2Fetcher fetcher = new StartingSearchV2Fetcher();
+        StartingSearchWithMetadataFetcher fetcher = new StartingSearchWithMetadataFetcher();
         DatasetGraph dsg = createPagedSearchTestDataset();
         TelicentExecutionContext context = new TelicentExecutionContext(dsg, "");
         DataFetchingEnvironment environment = DataFetchingEnvironmentImpl.newDataFetchingEnvironment()
@@ -331,7 +331,7 @@ public class TestStartingSearchFetcher {
     }
 
     @Test
-    public void givenPagedSearchResponse_whenUsingSearchFetcherV2WithLimitAndOffset_thenMetadataAndNoResults() throws
+    public void givenPagedSearchResponse_whenUsingSearchWithMetadataFetcherWithLimitAndOffset_thenMetadataAndNoResults() throws
             IOException {
         // given
         List<Map<?, ?>> resultItems = createPagedResultDocuments();
@@ -339,7 +339,7 @@ public class TestStartingSearchFetcher {
         WIRE_MOCK_SERVER.stubFor(get(urlEqualTo("/documents?query=test&limit=1&offset=4")).willReturn(
                 ok().withBody(MAPPER.writeValueAsString(pagedData))));
 
-        StartingSearchV2Fetcher fetcher = new StartingSearchV2Fetcher();
+        StartingSearchWithMetadataFetcher fetcher = new StartingSearchWithMetadataFetcher();
         DatasetGraph dsg = createPagedSearchTestDataset();
         TelicentExecutionContext context = new TelicentExecutionContext(dsg, "");
         DataFetchingEnvironment environment = DataFetchingEnvironmentImpl.newDataFetchingEnvironment()


### PR DESCRIPTION
Adds a new `searchV2()` query type to the Telicent Graph Schema with corresponding `SearchResults` response type.  Adds implementation of this model class and wiring for selecting the new fetcher.  Common logic between the two search queries is abstracted into a new abstract class.

# Outstanding Work

- [x] Add unit tests for the new query
- [x] Verify new query against SC-Search running in development environment
- [x] Documentation updates

# Related Issues and PRs

- This resolves CORE-428