### PR TITLE
Wrap fetcher data access in Txn.calculateRead()

### DIFF
--- a/graphql-fuseki-module/src/test/java/io/telicent/jena/graphql/fuseki/CountFetcher.java
+++ b/graphql-fuseki-module/src/test/java/io/telicent/jena/graphql/fuseki/CountFetcher.java
@@ -15,11 +15,12 @@ package io.telicent.jena.graphql.fuseki;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
 import org.apache.jena.sparql.core.DatasetGraph;
+import org.apache.jena.system.Txn;
 
 public class CountFetcher implements DataFetcher<Integer> {
     @Override
     public Integer get(DataFetchingEnvironment environment) {
         DatasetGraph dsg = environment.getLocalContext();
-        return (int) dsg.stream().count();
+        return Txn.calculateRead(dsg, () -> (int) dsg.stream().count());
     }
 }

--- a/graphql-jena-core/src/main/java/io/telicent/jena/graphql/fetchers/TraversalStartsFetcher.java
+++ b/graphql-jena-core/src/main/java/io/telicent/jena/graphql/fetchers/TraversalStartsFetcher.java
@@ -20,6 +20,7 @@ import io.telicent.jena.graphql.utils.NodeFilter;
 import org.apache.jena.graph.Node;
 import org.apache.jena.sparql.core.DatasetGraph;
 import org.apache.jena.sparql.core.Quad;
+import org.apache.jena.system.Txn;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -41,12 +42,12 @@ public class TraversalStartsFetcher implements DataFetcher<List<TraversalNode>> 
         DatasetGraph dsg = environment.getLocalContext();
         List<Node> startFilters = NodeFilter.parseList(environment.getArgument(TraversalSchema.STARTS_ARGUMENT));
 
-        return startFilters.stream()
-                           .distinct()
-                           .flatMap(n -> dsg.stream(Node.ANY, n, Node.ANY, Node.ANY))
-                           .map(Quad::getSubject)
-                           .distinct()
-                           .map(TraversalNode::of)
-                           .collect(Collectors.toList());
+        return Txn.calculateRead(dsg, () -> startFilters.stream()
+                                                        .distinct()
+                                                        .flatMap(n -> dsg.stream(Node.ANY, n, Node.ANY, Node.ANY))
+                                                        .map(Quad::getSubject)
+                                                        .distinct()
+                                                        .map(TraversalNode::of)
+                                                        .collect(Collectors.toList()));
     }
 }

--- a/graphql-jena-core/src/test/java/io/telicent/jena/graphql/fetchers/TestTraversalEdgesFetcher.java
+++ b/graphql-jena-core/src/test/java/io/telicent/jena/graphql/fetchers/TestTraversalEdgesFetcher.java
@@ -16,6 +16,7 @@ import graphql.execution.MergedField;
 import graphql.language.Field;
 import graphql.schema.DataFetchingEnvironment;
 import graphql.schema.DataFetchingEnvironmentImpl;
+import org.apache.jena.sparql.core.DatasetGraphFactory;
 import org.testng.annotations.Test;
 
 public class TestTraversalEdgesFetcher {
@@ -26,6 +27,7 @@ public class TestTraversalEdgesFetcher {
         MergedField mergedField = MergedField.newMergedField().addField(new Field("NoMatch")).build();
         DataFetchingEnvironment environment = DataFetchingEnvironmentImpl
                 .newDataFetchingEnvironment()
+                .localContext(DatasetGraphFactory.empty())
                 .mergedField(mergedField)
                 .build();
         TraversalEdgesFetcher traversalEdgesFetcher = new TraversalEdgesFetcher();

--- a/pom.xml
+++ b/pom.xml
@@ -128,9 +128,15 @@
                 <artifactId>jena-arq</artifactId>
                 <version>${dependency.jena}</version>
                 <exclusions>
+                    <!-- Excluded due to upstream Jena issue https://github.com/apache/jena/issues/2593 -->
                     <exclusion>
                         <groupId>org.junit.platform</groupId>
                         <artifactId>junit-platform-suite-engine</artifactId>
+                    </exclusion>
+                    <!-- Excluded due to CVE-2024-7254, GraphQL code doesn't need Protobuf anyway -->
+                    <exclusion>
+                        <groupId>com.google.protobuf</groupId>
+                        <artifactId>protobuf-java</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>

--- a/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/fetchers/telicent/graph/AbstractSearchFetcher.java
+++ b/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/fetchers/telicent/graph/AbstractSearchFetcher.java
@@ -29,6 +29,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.jena.graph.Node;
 import org.apache.jena.sparql.core.DatasetGraph;
 import org.apache.jena.sparql.core.Quad;
+import org.apache.jena.system.Txn;
 import org.apache.jena.web.HttpSC;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -47,6 +48,7 @@ import java.util.Map;
 
 /**
  * An abstract GraphQL fetcher for Search based queries
+ *
  * @param <T> Returned model type
  */
 public abstract class AbstractSearchFetcher<T> implements DataFetcher<T> {
@@ -183,12 +185,13 @@ public abstract class AbstractSearchFetcher<T> implements DataFetcher<T> {
                     "searchTerm") + ".  Search service may be unavailable in your environment.", e);
         }
 
-        List<TelicentGraphNode> nodes = startFilters.stream()
-                                                    .distinct()
-                                                    .filter(n -> StartingNodesFetcher.usedAsSubjectOrObject(n, dsg,
-                                                                                                            graphFilter))
-                                                    .map(n -> new TelicentGraphNode(n, dsg.prefixes()))
-                                                    .toList();
+        List<TelicentGraphNode> nodes = Txn.calculateRead(dsg, () -> startFilters.stream()
+                                                                                 .distinct()
+                                                                                 .filter(n -> StartingNodesFetcher.usedAsSubjectOrObject(
+                                                                                         n, dsg, graphFilter))
+                                                                                 .map(n -> new TelicentGraphNode(n,
+                                                                                                                 dsg.prefixes()))
+                                                                                 .toList());
         telicentResults.setNodes(nodes);
         return telicentResults;
     }

--- a/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/fetchers/telicent/graph/AllEntitiesFetcher.java
+++ b/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/fetchers/telicent/graph/AllEntitiesFetcher.java
@@ -21,6 +21,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.jena.graph.Node;
 import org.apache.jena.sparql.core.DatasetGraph;
 import org.apache.jena.sparql.core.Quad;
+import org.apache.jena.system.Txn;
 import org.apache.jena.vocabulary.RDF;
 
 import java.util.List;
@@ -45,6 +46,10 @@ public class AllEntitiesFetcher implements DataFetcher<List<TelicentGraphNode>> 
         String rawGraph = environment.getArgument(TelicentGraphSchema.ARGUMENT_GRAPH);
         Node graphFilter = StringUtils.isNotBlank(rawGraph) ? StartingNodesFetcher.parseStart(rawGraph) : Node.ANY;
 
+        return Txn.calculateRead(dsg, () -> findEntities(dsg, graphFilter));
+    }
+
+    private static List<TelicentGraphNode> findEntities(DatasetGraph dsg, Node graphFilter) {
         return dsg.stream(graphFilter, Node.ANY, RDF.type.asNode(), Node.ANY)
                   .filter(q -> q.getSubject().isURI() || q.getSubject().isBlank())
                   .map(Quad::getSubject)

--- a/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/fetchers/telicent/graph/InstancesFetcher.java
+++ b/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/fetchers/telicent/graph/InstancesFetcher.java
@@ -19,6 +19,7 @@ import io.telicent.jena.graphql.schemas.telicent.graph.models.TelicentGraphNode;
 import org.apache.jena.graph.Node;
 import org.apache.jena.sparql.core.DatasetGraph;
 import org.apache.jena.sparql.core.Quad;
+import org.apache.jena.system.Txn;
 import org.apache.jena.vocabulary.RDF;
 
 import java.util.List;
@@ -44,6 +45,10 @@ public class InstancesFetcher implements DataFetcher<List<TelicentGraphNode>> {
         DatasetGraph dsg = context.getDatasetGraph();
         TelicentGraphNode node = environment.getSource();
 
+        return Txn.calculateRead(dsg, () -> findInstances(dsg, node));
+    }
+
+    private static List<TelicentGraphNode> findInstances(DatasetGraph dsg, TelicentGraphNode node) {
         return dsg.stream(Node.ANY, Node.ANY, RDF_TYPE, node.getNode())
                   .filter(q -> q.getSubject().isURI() || q.getSubject().isBlank())
                   .map(Quad::getSubject)

--- a/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/fetchers/telicent/graph/LiteralPropertiesFetcher.java
+++ b/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/fetchers/telicent/graph/LiteralPropertiesFetcher.java
@@ -19,6 +19,7 @@ import io.telicent.jena.graphql.schemas.telicent.graph.models.TelicentGraphNode;
 import io.telicent.jena.graphql.schemas.telicent.graph.models.LiteralProperty;
 import org.apache.jena.graph.Node;
 import org.apache.jena.sparql.core.DatasetGraph;
+import org.apache.jena.system.Txn;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -41,9 +42,14 @@ public class LiteralPropertiesFetcher implements DataFetcher<List<LiteralPropert
         DatasetGraph dsg = context.getDatasetGraph();
         TelicentGraphNode node = environment.getSource();
 
+        return Txn.calculateRead(dsg, () -> findLiterals(dsg, node));
+    }
+
+    private static List<LiteralProperty> findLiterals(DatasetGraph dsg, TelicentGraphNode node) {
         return dsg.stream(Node.ANY, node.getNode(), Node.ANY, Node.ANY)
                   .filter(q -> q.getObject().isLiteral())
-                  .map(q -> new LiteralProperty(q.getPredicate(), q.getObject(), dsg.prefixes()))
+                  .map(q -> new LiteralProperty(q.getPredicate(), q.getObject(),
+                                                dsg.prefixes()))
                   .collect(Collectors.toList());
     }
 }

--- a/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/fetchers/telicent/graph/NodeTypesFetcher.java
+++ b/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/fetchers/telicent/graph/NodeTypesFetcher.java
@@ -19,6 +19,7 @@ import io.telicent.jena.graphql.schemas.telicent.graph.models.TelicentGraphNode;
 import org.apache.jena.graph.Node;
 import org.apache.jena.sparql.core.DatasetGraph;
 import org.apache.jena.sparql.core.Quad;
+import org.apache.jena.system.Txn;
 import org.apache.jena.vocabulary.RDF;
 
 import java.util.List;
@@ -35,12 +36,17 @@ public class NodeTypesFetcher implements DataFetcher<List<TelicentGraphNode>> {
     public NodeTypesFetcher() {
 
     }
+
     @Override
     public List<TelicentGraphNode> get(DataFetchingEnvironment environment) {
         TelicentExecutionContext context = environment.getLocalContext();
         DatasetGraph dsg = context.getDatasetGraph();
         TelicentGraphNode node = environment.getSource();
 
+        return Txn.calculateRead(dsg, () -> findRdfTypes(dsg, node));
+    }
+
+    private static List<TelicentGraphNode> findRdfTypes(DatasetGraph dsg, TelicentGraphNode node) {
         return dsg.stream(Node.ANY, node.getNode(), RDF.type.asNode(), Node.ANY)
                   .map(Quad::getObject)
                   .filter(t -> t.isURI() || t.isBlank())


### PR DESCRIPTION
Due to how GraphQL Java dispatches GraphQL queries asynchronously some of the data fetchers may run on a different thread than the one that originated the query.  This is problematic for Jena datasets where transactions are pinned to threads, therefore wrap all fetch logic that accesses a `DatasetGraph` in `Txn.calculateRead()`.  This is effectively a no-op if running on a thread that already has an active transaction, and creates a new one if necessary.  This fixes the intermittently seen `Not in a transaction` error.