### PR TITLE
Add Trivy Cache ignores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ dependency-reduced-pom.xml
 # OS X
 .DS_Store
 
+# Trivy Cache
+.trivy/

--- a/pom.xml
+++ b/pom.xml
@@ -302,6 +302,7 @@
                         <exclude>*-code-style.xml</exclude>
                         <exclude>docs/images/</exclude>
                         <exclude>temp.token</exclude>
+                        <exclude>.trivy/**</exclude>
                     </excludes>
                 </configuration>
             </plugin>
@@ -332,6 +333,7 @@
                                 <exclude>**/*.graphqls</exclude>
                                 <exclude>**/*.trig</exclude>
                                 <exclude>**/graphql-jena-server</exclude>
+                                <exclude>.trivy/**</exclude>
                             </excludes>
                         </licenseSet>
                     </licenseSets>


### PR DESCRIPTION
This fixes Maven blowing up with OOM as some plugins are trying to read the very large Java DB files and exhausting memory on GitHub Actions runners.