### PR TITLE
Adds relCounts property to Node type in Telicent Schema (CORE-801)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # GraphQL Extensions for Apache Jena
 
+# 0.10.0
+
+- Telicent Graph Schema improvements:
+    - Added new `relCounts` property to `Node` type to allow summarising available relationships
+
 # 0.9.3
 
 - Build improvements:

--- a/graphql-fuseki-module/pom.xml
+++ b/graphql-fuseki-module/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.telicent.jena.graphql</groupId>
         <artifactId>parent</artifactId>
-        <version>0.9.4-SNAPSHOT</version>
+        <version>0.10.0-SNAPSHOT</version>
     </parent>
     <artifactId>graphql-fuseki-module</artifactId>
     <name>Telicent - GraphQL for Apache Jena - Fuseki Module</name>

--- a/graphql-jena-core/pom.xml
+++ b/graphql-jena-core/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.telicent.jena.graphql</groupId>
         <artifactId>parent</artifactId>
-        <version>0.9.4-SNAPSHOT</version>
+        <version>0.10.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>graphql-jena-core</artifactId>

--- a/graphql-server/pom.xml
+++ b/graphql-server/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.telicent.jena.graphql</groupId>
         <artifactId>parent</artifactId>
-        <version>0.9.4-SNAPSHOT</version>
+        <version>0.10.0-SNAPSHOT</version>
     </parent>
     <artifactId>graphql-server</artifactId>
     <name>Telicent - GraphQL for Apache Jena - Standalone Server</name>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>io.telicent.jena.graphql</groupId>
     <artifactId>parent</artifactId>
-    <version>0.9.4-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Telicent - GraphQL for Apache Jena - Parent</name>
     <description>Provides GraphQL extensions for use with Apache Jena</description>

--- a/telicent-graph-schema/pom.xml
+++ b/telicent-graph-schema/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.telicent.jena.graphql</groupId>
         <artifactId>parent</artifactId>
-        <version>0.9.4-SNAPSHOT</version>
+        <version>0.10.0-SNAPSHOT</version>
     </parent>
     <artifactId>telicent-graph-schema</artifactId>
     <name>Telicent - GraphQL for Apache Jena - Telicent Graph Application Schema</name>

--- a/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/execution/telicent/graph/TelicentGraphExecutor.java
+++ b/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/execution/telicent/graph/TelicentGraphExecutor.java
@@ -69,6 +69,7 @@ public class TelicentGraphExecutor extends AbstractDatasetExecutor {
                                         .dataFetcher(TelicentGraphSchema.FIELD_PROPERTIES, new LiteralPropertiesFetcher())
                                         .dataFetcher(TelicentGraphSchema.FIELD_INBOUND_RELATIONSHIPS, new RelationshipsFetcher(EdgeDirection.IN))
                                         .dataFetcher(TelicentGraphSchema.FIELD_OUTBOUND_RELATIONSHIPS, new RelationshipsFetcher(EdgeDirection.OUT))
+                                        .dataFetcher(TelicentGraphSchema.FIELD_RELATIONSHIP_COUNTS, new RelationshipCountsFetcher())
                                         .dataFetcher(TelicentGraphSchema.FIELD_INSTANCES, new InstancesFetcher()))
                             .type(TelicentGraphSchema.TYPE_RELATIONSHIP,
                                   // The Telicent Graph schema uses underscores in these property names which defeats
@@ -76,6 +77,7 @@ public class TelicentGraphExecutor extends AbstractDatasetExecutor {
                                   // have to explicitly declare the fetchers for these
                                   t -> t.dataFetcher(TelicentGraphSchema.FIELD_DOMAIN_ID, new PropertyDataFetcher<String>("domainId"))
                                         .dataFetcher(TelicentGraphSchema.FIELD_RANGE_ID, new PropertyDataFetcher<String>("rangeId")))
+                            // NB - As RelationshipsCount is a simple POJO no explicit wiring needing for RelCounts type
                             .type(TelicentGraphSchema.TYPE_STATE,
                                   t -> t.dataFetcher(TelicentGraphSchema.FIELD_TYPE, new StateTypeFetcher())
                                         .dataFetcher(TelicentGraphSchema.FIELD_RELATIONS, new StateRelationshipsFetcher())

--- a/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/fetchers/telicent/graph/RelationshipCountsFetcher.java
+++ b/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/fetchers/telicent/graph/RelationshipCountsFetcher.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright (C) Telicent Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.telicent.jena.graphql.fetchers.telicent.graph;
+
+import graphql.schema.DataFetcher;
+import graphql.schema.DataFetchingEnvironment;
+import io.telicent.jena.graphql.execution.telicent.graph.TelicentExecutionContext;
+import io.telicent.jena.graphql.schemas.models.EdgeDirection;
+import io.telicent.jena.graphql.schemas.telicent.graph.models.Relationship;
+import io.telicent.jena.graphql.schemas.telicent.graph.models.RelationshipCounts;
+import io.telicent.jena.graphql.schemas.telicent.graph.models.TelicentGraphNode;
+import org.apache.jena.graph.Node;
+import org.apache.jena.sparql.core.DatasetGraph;
+import org.apache.jena.sparql.core.Quad;
+import org.apache.jena.system.Txn;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * A GraphQL {@link DataFetcher} that finds the counts of incoming/outgoing relationships for a node
+ */
+public class RelationshipCountsFetcher implements DataFetcher<RelationshipCounts> {
+
+    /**
+     * Creates a new relationship counts fetcher
+     */
+    public RelationshipCountsFetcher() {}
+
+    @Override
+    public RelationshipCounts get(DataFetchingEnvironment environment) {
+        TelicentExecutionContext context = environment.getLocalContext();
+        DatasetGraph dsg = context.getDatasetGraph();
+        TelicentGraphNode target = environment.getSource();
+
+        return Txn.calculateRead(dsg, () -> countRelationships(dsg, target));
+    }
+
+    private RelationshipCounts countRelationships(DatasetGraph dsg, TelicentGraphNode target) {
+        return new RelationshipCounts(stream(dsg, target, EdgeDirection.IN), stream(dsg, target, EdgeDirection.OUT));
+    }
+
+    private int stream(DatasetGraph dsg, TelicentGraphNode target, EdgeDirection direction) {
+        return Math.toIntExact(streamTargets(dsg, target, direction).filter(n -> n.isURI() || n.isBlank()).count());
+    }
+
+    private static Stream<Node> streamTargets(DatasetGraph dsg, TelicentGraphNode target, EdgeDirection direction) {
+        return switch (direction) {
+            case OUT -> dsg.stream(Node.ANY, target.getNode(), Node.ANY, Node.ANY).map(Quad::getObject);
+            case IN -> dsg.stream(Node.ANY, Node.ANY, Node.ANY, target.getNode()).map(Quad::getSubject);
+        };
+    }
+}

--- a/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/schemas/telicent/graph/TelicentGraphSchema.java
+++ b/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/schemas/telicent/graph/TelicentGraphSchema.java
@@ -50,6 +50,10 @@ public class TelicentGraphSchema {
      */
     public static final String TYPE_RELATIONSHIP = "Rel";
     /**
+     * Relationship counts type
+     */
+    public static final String TYPE_RELATIONSHIP_COUNTS = "RelCounts";
+    /**
      * Property type
      */
     public static final String TYPE_PROPERTY = "Property";
@@ -142,6 +146,10 @@ public class TelicentGraphSchema {
      */
     public static final String FIELD_OUTBOUND_RELATIONSHIPS = "outRels";
     /**
+     * Relationship counts field
+     */
+    public static final String FIELD_RELATIONSHIP_COUNTS = "relCounts";
+    /**
      * URI field
      */
     public static final String FIELD_URI = ARGUMENT_URI;
@@ -181,6 +189,14 @@ public class TelicentGraphSchema {
      * Relations field
      */
     public static final String FIELD_RELATIONS = "relations";
+    /**
+     * In field
+     */
+    public static final String FIELD_IN = "in";
+    /**
+     * Out field
+     */
+    public static final String FIELD_OUT = "out";
 
     /**
      * Extension property used to supply the users authentication token that may be passed on by some

--- a/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/schemas/telicent/graph/models/RelationshipCounts.java
+++ b/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/schemas/telicent/graph/models/RelationshipCounts.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (C) Telicent Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.telicent.jena.graphql.schemas.telicent.graph.models;
+
+/**
+ * Holds information about relationship counts
+ * <p>
+ * This is intentionally an object so we can potentially augment this with further fields in the future if we need to.
+ * </p>
+ */
+public class RelationshipCounts {
+
+    private final int in, out;
+
+    /**
+     * Creates new relationship counts
+     *
+     * @param in  Count of incoming relationships
+     * @param out Count of outgoing relationships
+     */
+    public RelationshipCounts(int in, int out) {
+        this.in = in;
+        this.out = out;
+    }
+
+    /**
+     * Gets the count of incoming relationships
+     *
+     * @return Incoming relationships count
+     */
+    public int getIn() {
+        return in;
+    }
+
+    /**
+     * Gets the count of outgoing relationships
+     *
+     * @return Outgoing relationships count
+     */
+    public int getOut() {
+        return out;
+    }
+}

--- a/telicent-graph-schema/src/main/resources/io/telicent/jena/graphql/schemas/telicent/graph/ies.graphqls
+++ b/telicent-graph-schema/src/main/resources/io/telicent/jena/graphql/schemas/telicent/graph/ies.graphqls
@@ -7,6 +7,7 @@ type Node {
     properties: [Property]! #An array of literal properties of the Node
     outRels: [Rel]! #An array of Rels where the current Node is in the domain position
     inRels: [Rel]! #An array of Rels where the current Node is in the range position
+    relCounts: RelCounts!
     instances: [Node] #If the node is a class, this will return an array of its instances
 }
 
@@ -17,6 +18,11 @@ type Rel { #A subject-predicate-object statement
     predicate: String! #AKA property
     range_id: String!
     range: Node! #AKA object
+}
+
+type RelCounts {
+    in: Int
+    out: Int
 }
 
 type Property { #A literal property

--- a/telicent-graph-schema/src/test/java/io/telicent/jena/graphql/execution/telicent/graph/TestTelicentGraphExecution.java
+++ b/telicent-graph-schema/src/test/java/io/telicent/jena/graphql/execution/telicent/graph/TestTelicentGraphExecution.java
@@ -99,7 +99,7 @@ public class TestTelicentGraphExecution extends AbstractExecutionTests {
     }
 
     @Test
-    public void givenStarWarsData_whenQueryingForSingleNode_thenSingleResult() {
+    public void givenStarWarsData_whenQueryingForSingleNode_thenSingleResult_andRelCountsAreAccurate() {
         // Given and When
         ExecutionResult result = verifyExecution(this.starwars, SINGLE_NODE_QUERY);
 
@@ -112,6 +112,16 @@ public class TestTelicentGraphExecution extends AbstractExecutionTests {
         verifyNodeResult(data, OBI_WAN_KENOBI, "starwars:person_Obi-WanKenobi");
         Assert.assertNotNull(data.get(TelicentGraphSchema.FIELD_INSTANCES));
         Assert.assertTrue(((List<Object>) data.get(TelicentGraphSchema.FIELD_INSTANCES)).isEmpty());
+
+        // And
+        Map<String, Object> relCounts = (Map<String, Object>) data.get(TelicentGraphSchema.FIELD_RELATIONSHIP_COUNTS);
+        Assert.assertNotNull(relCounts);
+        List<?> outRels = (List<?>)data.get(TelicentGraphSchema.FIELD_OUTBOUND_RELATIONSHIPS);
+        List<?> inRels = (List<?>)data.get(TelicentGraphSchema.FIELD_INBOUND_RELATIONSHIPS);
+        Assert.assertNotNull(outRels);
+        Assert.assertNotNull(inRels);
+        Assert.assertEquals(outRels.size(), (Integer)relCounts.get(TelicentGraphSchema.FIELD_OUT));
+        Assert.assertEquals(inRels.size(), (Integer)relCounts.get(TelicentGraphSchema.FIELD_IN));
     }
 
     private static void verifyNodeResult(Map<String, Object> data, String fullUri, String shortUri) {

--- a/telicent-graph-schema/src/test/java/io/telicent/jena/graphql/fetchers/telicent/graph/TestRelationshipsFetcher.java
+++ b/telicent-graph-schema/src/test/java/io/telicent/jena/graphql/fetchers/telicent/graph/TestRelationshipsFetcher.java
@@ -34,9 +34,9 @@ public class TestRelationshipsFetcher {
         // given
         RelationshipsFetcher fetcher = new RelationshipsFetcher(EdgeDirection.IN);
         DatasetGraph dsg  = DatasetGraphFactory.create();
-        dsg.add(new Quad(createLiteralString("graph"), createLiteralString("subject1"), createLiteralString("predicate1"), createLiteralString("object")));
-        dsg.add(new Quad(createLiteralString("graph"), createLiteralString("subject2"), createLiteralString("predicate2"), createBlankNode("object")));
-        dsg.add(new Quad(createLiteralString("graph"), createLiteralString("subject3"), createLiteralString("predicate3"), createURI("object")));
+        dsg.add(new Quad(createURI("graph"), createURI("subject1"), createURI("predicate1"), createLiteralString("object")));
+        dsg.add(new Quad(createURI("graph"), createURI("subject2"), createURI("predicate2"), createBlankNode("object")));
+        dsg.add(new Quad(createURI("graph"), createURI("subject3"), createURI("predicate3"), createURI("object")));
 
         TelicentExecutionContext context = new TelicentExecutionContext(dsg, "");
         DataFetchingEnvironment environment = DataFetchingEnvironmentImpl
@@ -56,9 +56,9 @@ public class TestRelationshipsFetcher {
         // given
         RelationshipsFetcher fetcher = new RelationshipsFetcher(EdgeDirection.IN);
         DatasetGraph dsg  = DatasetGraphFactory.create();
-        dsg.add(new Quad(createLiteralString("graph"), createLiteralString("subject1"), createLiteralString("predicate1"), createLiteralString("object")));
-        dsg.add(new Quad(createLiteralString("graph"), createLiteralString("subject2"), createLiteralString("predicate2"), createBlankNode("object")));
-        dsg.add(new Quad(createLiteralString("graph"), createLiteralString("subject3"), createLiteralString("predicate3"), createURI("object")));
+        dsg.add(new Quad(createURI("graph"), createURI("subject1"), createURI("predicate1"), createLiteralString("object")));
+        dsg.add(new Quad(createURI("graph"), createURI("subject2"), createURI("predicate2"), createBlankNode("object")));
+        dsg.add(new Quad(createURI("graph"), createURI("subject3"), createURI("predicate3"), createURI("object")));
 
         TelicentExecutionContext context = new TelicentExecutionContext(dsg, "");
         DataFetchingEnvironment environment = DataFetchingEnvironmentImpl

--- a/telicent-graph-schema/src/test/resources/queries/telicent/graph/single-node.graphql
+++ b/telicent-graph-schema/src/test/resources/queries/telicent/graph/single-node.graphql
@@ -23,6 +23,10 @@ query {
             }
             range_id
         }
+        relCounts {
+            in
+            out
+        }
         instances {
             uri
         }


### PR DESCRIPTION
Adds a new `relCounts` property to `Node` type, this has the type of `RelationshipsCount` which has in and out properties.  Includes new fetcher and minor code changes to existing relationships fetcher.