### PR TITLE
Support limit offset pagination in Telicent schema (CORE-801)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 # 0.10.0
 
 - Telicent Graph Schema improvements:
-    - Added new `relCounts` property to `Node` type to allow summarising available relationships
+    - Added new `relCounts` property to `Node` and `State` types to allow summarising available relationships
     - Added `limit` and `offset` parameters to various list fields, in combination with the new `relCounts` field this
       allows paging through the results
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Telicent Graph Schema improvements:
     - Added new `relCounts` property to `Node` type to allow summarising available relationships
+    - Added `limit` and `offset` parameters to various list fields, in combination with the new `relCounts` field this
+      allows paging through the results
 
 # 0.9.3
 

--- a/graphql-fuseki-module/src/test/java/io/telicent/jena/graphql/fuseki/TestFusekiGraphQL.java
+++ b/graphql-fuseki-module/src/test/java/io/telicent/jena/graphql/fuseki/TestFusekiGraphQL.java
@@ -29,7 +29,6 @@ import io.telicent.jena.graphql.server.model.GraphQLRequest;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.jena.fuseki.main.FusekiServer;
-import org.apache.jena.fuseki.main.sys.FusekiAutoModules;
 import org.apache.jena.fuseki.main.sys.FusekiModules;
 import org.apache.jena.fuseki.server.DataAccessPoint;
 import org.apache.jena.fuseki.servlets.CrossOriginFilter;

--- a/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/execution/telicent/graph/TelicentGraphExecutor.java
+++ b/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/execution/telicent/graph/TelicentGraphExecutor.java
@@ -21,6 +21,7 @@ import io.telicent.jena.graphql.fetchers.telicent.graph.*;
 import io.telicent.jena.graphql.schemas.models.EdgeDirection;
 import io.telicent.jena.graphql.schemas.telicent.graph.TelicentGraphSchema;
 import io.telicent.jena.graphql.schemas.telicent.graph.models.SearchType;
+import io.telicent.jena.graphql.schemas.telicent.graph.models.TelicentGraphNode;
 import org.apache.jena.sparql.core.DatasetGraph;
 
 import java.io.IOException;
@@ -63,32 +64,40 @@ public class TelicentGraphExecutor extends AbstractDatasetExecutor {
                                         .dataFetcher(TelicentGraphSchema.QUERY_SEARCH, new StartingSearchFetcher())
                                         .dataFetcher(TelicentGraphSchema.QUERY_SEARCH_WITH_METADATA, new StartingSearchWithMetadataFetcher()).enumValues(nodeKinds)
                                         .dataFetcher(TelicentGraphSchema.QUERY_STATES, new StartingStatesFetcher())
-                                        .dataFetcher(TelicentGraphSchema.QUERY_GET_ALL_ENTITIES, new AllEntitiesFetcher()))
+                                        .dataFetcher(TelicentGraphSchema.QUERY_GET_ALL_ENTITIES, new AllEntitiesFetcher())
+                            )
                             .type(TelicentGraphSchema.TYPE_NODE,
                                   t -> t.dataFetcher(TelicentGraphSchema.FIELD_TYPES, new NodeTypesFetcher())
                                         .dataFetcher(TelicentGraphSchema.FIELD_PROPERTIES, new LiteralPropertiesFetcher())
                                         .dataFetcher(TelicentGraphSchema.FIELD_INBOUND_RELATIONSHIPS, new RelationshipsFetcher(EdgeDirection.IN))
                                         .dataFetcher(TelicentGraphSchema.FIELD_OUTBOUND_RELATIONSHIPS, new RelationshipsFetcher(EdgeDirection.OUT))
                                         .dataFetcher(TelicentGraphSchema.FIELD_INSTANCES, new InstancesFetcher())
-                                        .dataFetcher(TelicentGraphSchema.FIELD_RELATIONSHIP_COUNTS, new RelationshipCountsPlaceholderFetcher()))
+                                        .dataFetcher(TelicentGraphSchema.FIELD_RELATIONSHIP_COUNTS, new RelationshipCountsPlaceholderFetcher())
+                            )
                             .type(TelicentGraphSchema.TYPE_RELATIONSHIP,
                                   // The Telicent Graph schema uses underscores in these property names which defeats
                                   // graphql-java's default logic of looking for an equivalent Java property name so
                                   // have to explicitly declare the fetchers for these
                                   t -> t.dataFetcher(TelicentGraphSchema.FIELD_DOMAIN_ID, new PropertyDataFetcher<String>("domainId"))
-                                        .dataFetcher(TelicentGraphSchema.FIELD_RANGE_ID, new PropertyDataFetcher<String>("rangeId")))
+                                        .dataFetcher(TelicentGraphSchema.FIELD_RANGE_ID, new PropertyDataFetcher<String>("rangeId"))
+                            )
                             .type(TelicentGraphSchema.TYPE_RELATIONSHIP_COUNTS,
                                         t -> t.dataFetcher(TelicentGraphSchema.FIELD_INBOUND_RELATIONSHIPS, new RelationshipCountsFetcher(EdgeDirection.IN))
                                               .dataFetcher(TelicentGraphSchema.FIELD_OUTBOUND_RELATIONSHIPS, new RelationshipCountsFetcher(EdgeDirection.OUT))
                                               .dataFetcher(TelicentGraphSchema.FIELD_INSTANCES, new InstancesCountFetcher())
                                               .dataFetcher(TelicentGraphSchema.FIELD_TYPES, new NodeTypeCountsFetcher())
-                                              .dataFetcher(TelicentGraphSchema.FIELD_PROPERTIES, new LiteralsCountFetcher()))
+                                              .dataFetcher(TelicentGraphSchema.FIELD_PROPERTIES, new LiteralsCountFetcher())
+                            )
                             .type(TelicentGraphSchema.TYPE_STATE,
                                   t -> t.dataFetcher(TelicentGraphSchema.FIELD_TYPE, new StateTypeFetcher())
                                         .dataFetcher(TelicentGraphSchema.FIELD_RELATIONS, new StateRelationshipsFetcher())
                                         .dataFetcher(TelicentGraphSchema.FIELD_START, periodFetcher)
                                         .dataFetcher(TelicentGraphSchema.FIELD_END, periodFetcher)
                                         .dataFetcher(TelicentGraphSchema.FIELD_PERIOD, periodFetcher)
+                                        .dataFetcher(TelicentGraphSchema.FIELD_RELATIONSHIP_COUNTS, new StateRelationshipCountsPlaceholderFetcher())
+                            )
+                            .type(TelicentGraphSchema.TYPE_STATE_RELATIONSHIP_COUNTS,
+                                  t -> t.dataFetcher(TelicentGraphSchema.FIELD_RELATIONS, new StateRelationshipCountsFetcher())
                             );
         //@formatter:on
     }

--- a/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/execution/telicent/graph/TelicentGraphExecutor.java
+++ b/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/execution/telicent/graph/TelicentGraphExecutor.java
@@ -69,15 +69,20 @@ public class TelicentGraphExecutor extends AbstractDatasetExecutor {
                                         .dataFetcher(TelicentGraphSchema.FIELD_PROPERTIES, new LiteralPropertiesFetcher())
                                         .dataFetcher(TelicentGraphSchema.FIELD_INBOUND_RELATIONSHIPS, new RelationshipsFetcher(EdgeDirection.IN))
                                         .dataFetcher(TelicentGraphSchema.FIELD_OUTBOUND_RELATIONSHIPS, new RelationshipsFetcher(EdgeDirection.OUT))
-                                        .dataFetcher(TelicentGraphSchema.FIELD_RELATIONSHIP_COUNTS, new RelationshipCountsFetcher())
-                                        .dataFetcher(TelicentGraphSchema.FIELD_INSTANCES, new InstancesFetcher()))
+                                        .dataFetcher(TelicentGraphSchema.FIELD_INSTANCES, new InstancesFetcher())
+                                        .dataFetcher(TelicentGraphSchema.FIELD_RELATIONSHIP_COUNTS, new RelationshipCountsPlaceholderFetcher()))
                             .type(TelicentGraphSchema.TYPE_RELATIONSHIP,
                                   // The Telicent Graph schema uses underscores in these property names which defeats
                                   // graphql-java's default logic of looking for an equivalent Java property name so
                                   // have to explicitly declare the fetchers for these
                                   t -> t.dataFetcher(TelicentGraphSchema.FIELD_DOMAIN_ID, new PropertyDataFetcher<String>("domainId"))
                                         .dataFetcher(TelicentGraphSchema.FIELD_RANGE_ID, new PropertyDataFetcher<String>("rangeId")))
-                            // NB - As RelationshipsCount is a simple POJO no explicit wiring needing for RelCounts type
+                            .type(TelicentGraphSchema.TYPE_RELATIONSHIP_COUNTS,
+                                        t -> t.dataFetcher(TelicentGraphSchema.FIELD_INBOUND_RELATIONSHIPS, new RelationshipCountsFetcher(EdgeDirection.IN))
+                                              .dataFetcher(TelicentGraphSchema.FIELD_OUTBOUND_RELATIONSHIPS, new RelationshipCountsFetcher(EdgeDirection.OUT))
+                                              .dataFetcher(TelicentGraphSchema.FIELD_INSTANCES, new InstancesCountFetcher())
+                                              .dataFetcher(TelicentGraphSchema.FIELD_TYPES, new NodeTypeCountsFetcher())
+                                              .dataFetcher(TelicentGraphSchema.FIELD_PROPERTIES, new LiteralsCountFetcher()))
                             .type(TelicentGraphSchema.TYPE_STATE,
                                   t -> t.dataFetcher(TelicentGraphSchema.FIELD_TYPE, new StateTypeFetcher())
                                         .dataFetcher(TelicentGraphSchema.FIELD_RELATIONS, new StateRelationshipsFetcher())

--- a/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/fetchers/telicent/graph/AbstractLimitOffsetPagingFetcher.java
+++ b/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/fetchers/telicent/graph/AbstractLimitOffsetPagingFetcher.java
@@ -1,0 +1,118 @@
+/**
+ * Copyright (C) Telicent Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.telicent.jena.graphql.fetchers.telicent.graph;
+
+import graphql.schema.DataFetcher;
+import graphql.schema.DataFetchingEnvironment;
+import io.telicent.jena.graphql.execution.telicent.graph.TelicentExecutionContext;
+import io.telicent.jena.graphql.schemas.telicent.graph.TelicentGraphSchema;
+import org.apache.jena.sparql.core.DatasetGraph;
+import org.apache.jena.system.Txn;
+
+import java.util.stream.Stream;
+
+/**
+ * Abstract base class for GraphQL {@link graphql.schema.DataFetcher} implementations that support paging on their
+ * results using {@code limit} and {@code offset} arguments
+ */
+public abstract class AbstractLimitOffsetPagingFetcher<TSource, TInput, TOutput> implements DataFetcher<TOutput> {
+
+    private final long defaultLimit, maxLimit;
+
+    /**
+     * Creates a new paging fetcher with default limit settings
+     */
+    protected AbstractLimitOffsetPagingFetcher() {
+        this(TelicentGraphSchema.DEFAULT_LIMIT, TelicentGraphSchema.MAX_LIMIT);
+    }
+
+    /**
+     * Creates a new paging fetcher with custom limit settings
+     *
+     * @param defaultLimit Default limit to apply if none specified
+     * @param maxLimit     Maximum limit to permit
+     */
+    protected AbstractLimitOffsetPagingFetcher(long defaultLimit, long maxLimit) {
+        this.defaultLimit = defaultLimit;
+        this.maxLimit = maxLimit;
+    }
+
+    @Override
+    public final TOutput get(DataFetchingEnvironment environment) throws Exception {
+        TelicentExecutionContext context = environment.getLocalContext();
+        DatasetGraph dsg = context.getDatasetGraph();
+        TSource source = getSource(environment);
+        return Txn.calculateRead(dsg, () -> {
+            Stream<TInput> input = select(environment, dsg, source);
+            Stream<TInput> paged = applyLimitAndOffset(environment, input);
+            return map(environment, dsg, source, paged);
+        });
+    }
+
+    /**
+     * Gets the source needed for this fetcher implementation
+     * <p>
+     * This is provided for fetchers where the source won't be directly of the type this fetcher requires
+     * <strong>BUT</strong> they can use their actual source type to get an instance of the necessary source type.
+     * </p>
+     *
+     * @param environment Data Fetching environment
+     * @return Source
+     */
+    protected TSource getSource(DataFetchingEnvironment environment) {
+        return environment.getSource();
+    }
+
+    /**
+     * Performs the initial select of relevant data
+     *
+     * @param environment Data Fetching Environment
+     * @param dsg         Dataset Graph
+     * @param source      Source object used to control what is selected
+     * @return Initial data selection
+     */
+    protected abstract Stream<TInput> select(DataFetchingEnvironment environment, DatasetGraph dsg, TSource source);
+
+    /**
+     * Performs the mapping of the paged input data to output data
+     *
+     * @param environment Data Fetching Environment
+     * @param dsg         Dataset Graph
+     * @param source      Source object from which the input data was selected
+     * @param input       Paged input data
+     * @return Output data
+     */
+    protected abstract TOutput map(DataFetchingEnvironment environment, DatasetGraph dsg, TSource source,
+                                   Stream<TInput> input);
+
+    /**
+     * Applies limit and offset, if any, to the given stream
+     *
+     * @param environment Data Fetching environment
+     * @param stream      Stream to apply paging to
+     * @return Stream with paging applied
+     */
+    protected Stream<TInput> applyLimitAndOffset(DataFetchingEnvironment environment, Stream<TInput> stream) {
+        Integer limit = environment.getArgument(TelicentGraphSchema.ARGUMENT_LIMIT);
+        Integer offset = environment.getArgument(TelicentGraphSchema.ARGUMENT_OFFSET);
+        if (offset != null && offset > 1) {
+            stream = stream.skip(offset.longValue() - 1);
+        }
+        if (limit != null && limit > 0) {
+            stream = stream.limit(Math.min(limit.longValue(), this.maxLimit));
+        } else {
+            stream = stream.limit(this.defaultLimit);
+        }
+        return stream;
+    }
+}

--- a/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/fetchers/telicent/graph/AbstractLiteralsFetcher.java
+++ b/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/fetchers/telicent/graph/AbstractLiteralsFetcher.java
@@ -12,32 +12,22 @@
  */
 package io.telicent.jena.graphql.fetchers.telicent.graph;
 
-import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
 import io.telicent.jena.graphql.schemas.telicent.graph.models.TelicentGraphNode;
 import org.apache.jena.graph.Node;
 import org.apache.jena.sparql.core.DatasetGraph;
+import org.apache.jena.sparql.core.Quad;
 
-import java.util.List;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
- * A GraphQL {@link DataFetcher} that finds instances of a type
+ * Abstract data fetcher that finds literals directly attached to nodes
+ * @param <TOutput> Output type
  */
-public class InstancesFetcher
-        extends AbstractInstancesFetcher<List<TelicentGraphNode>> {
-
-    /**
-     * Creates a fetcher that finds all instances of a type
-     */
-    public InstancesFetcher() {
-
-    }
-
+public abstract class AbstractLiteralsFetcher<TOutput>
+        extends AbstractLimitOffsetPagingFetcher<TelicentGraphNode, Quad, TOutput> {
     @Override
-    protected List<TelicentGraphNode> map(DataFetchingEnvironment environment, DatasetGraph dsg,
-                                          TelicentGraphNode source, Stream<Node> input) {
-        return input.map(n -> new TelicentGraphNode(n, dsg.prefixes())).collect(Collectors.toList());
+    protected Stream<Quad> select(DataFetchingEnvironment environment, DatasetGraph dsg, TelicentGraphNode node) {
+        return dsg.stream(Node.ANY, node.getNode(), Node.ANY, Node.ANY).filter(q -> q.getObject().isLiteral());
     }
 }

--- a/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/fetchers/telicent/graph/AbstractNodeTypesFetcher.java
+++ b/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/fetchers/telicent/graph/AbstractNodeTypesFetcher.java
@@ -12,32 +12,26 @@
  */
 package io.telicent.jena.graphql.fetchers.telicent.graph;
 
-import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
 import io.telicent.jena.graphql.schemas.telicent.graph.models.TelicentGraphNode;
 import org.apache.jena.graph.Node;
 import org.apache.jena.sparql.core.DatasetGraph;
+import org.apache.jena.sparql.core.Quad;
+import org.apache.jena.vocabulary.RDF;
 
-import java.util.List;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
- * A GraphQL {@link DataFetcher} that finds instances of a type
+ * Abstract data fetcher that finds the declared {@code rdf:type}'s for a node
+ *
+ * @param <TOutput> Output type
  */
-public class InstancesFetcher
-        extends AbstractInstancesFetcher<List<TelicentGraphNode>> {
-
-    /**
-     * Creates a fetcher that finds all instances of a type
-     */
-    public InstancesFetcher() {
-
-    }
-
+public abstract class AbstractNodeTypesFetcher<TOutput>
+        extends AbstractLimitOffsetPagingFetcher<TelicentGraphNode, Node, TOutput> {
     @Override
-    protected List<TelicentGraphNode> map(DataFetchingEnvironment environment, DatasetGraph dsg,
-                                          TelicentGraphNode source, Stream<Node> input) {
-        return input.map(n -> new TelicentGraphNode(n, dsg.prefixes())).collect(Collectors.toList());
+    protected Stream<Node> select(DataFetchingEnvironment environment, DatasetGraph dsg, TelicentGraphNode node) {
+        return dsg.stream(Node.ANY, node.getNode(), RDF.type.asNode(), Node.ANY)
+                  .map(Quad::getObject)
+                  .filter(t -> t.isURI() || t.isBlank());
     }
 }

--- a/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/fetchers/telicent/graph/AbstractRelationshipsFetcher.java
+++ b/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/fetchers/telicent/graph/AbstractRelationshipsFetcher.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright (C) Telicent Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.telicent.jena.graphql.fetchers.telicent.graph;
+
+import graphql.schema.DataFetchingEnvironment;
+import io.telicent.jena.graphql.schemas.models.EdgeDirection;
+import io.telicent.jena.graphql.schemas.telicent.graph.models.TelicentGraphNode;
+import org.apache.jena.graph.Node;
+import org.apache.jena.sparql.core.DatasetGraph;
+import org.apache.jena.sparql.core.Quad;
+
+import java.util.stream.Stream;
+
+/**
+ * Abstract data fetcher for finding relationships going in/out of a node
+ *
+ * @param <TOutput> Output type
+ */
+public abstract class AbstractRelationshipsFetcher<TOutput>
+        extends AbstractLimitOffsetPagingFetcher<TelicentGraphNode, Quad, TOutput> {
+    /**
+     * The direction of relationships we're configured to fetch
+     */
+    protected final EdgeDirection direction;
+
+    /**
+     * Creates a new relationships fetcher
+     *
+     * @param direction Direction of relationships to fetch
+     */
+    protected AbstractRelationshipsFetcher(EdgeDirection direction) {
+        this.direction = direction;
+    }
+
+    @Override
+    protected Stream<Quad> select(DataFetchingEnvironment environment, DatasetGraph dsg, TelicentGraphNode node) {
+        return stream(dsg, node);
+    }
+
+    private Stream<Quad> stream(DatasetGraph dsg, TelicentGraphNode node) {
+        // NB - We filter() because we only care about relationships to other nodes, not literals, the filter is
+        //      different depending on the edge direction as it's the target node we care about, which is either the
+        //      object for OUT relationships, or the subject for IN relationships
+        return switch (this.direction) {
+            case OUT -> dsg.stream(Node.ANY, node.getNode(), Node.ANY, Node.ANY)
+                           .filter(q -> q.getObject().isURI() || q.getObject().isBlank());
+            case IN -> dsg.stream(Node.ANY, Node.ANY, Node.ANY, node.getNode())
+                          .filter(q -> q.getSubject().isURI() || q.getSubject().isBlank());
+        };
+    }
+}

--- a/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/fetchers/telicent/graph/AbstractStateRelationshipsFetcher.java
+++ b/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/fetchers/telicent/graph/AbstractStateRelationshipsFetcher.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright (C) Telicent Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.telicent.jena.graphql.fetchers.telicent.graph;
+
+import graphql.com.google.common.collect.Streams;
+import graphql.schema.DataFetchingEnvironment;
+import io.telicent.jena.graphql.schemas.telicent.graph.models.State;
+import org.apache.jena.graph.Node;
+import org.apache.jena.sparql.core.DatasetGraph;
+import org.apache.jena.sparql.core.Quad;
+import org.apache.jena.vocabulary.RDF;
+
+import java.util.stream.Stream;
+
+/**
+ * Abstract data fetcher for fetching relationships for states
+ *
+ * @param <TOutput> Output type
+ */
+public abstract class AbstractStateRelationshipsFetcher<TOutput>
+        extends AbstractLimitOffsetPagingFetcher<State, Quad, TOutput> {
+    private static Stream<Quad> outbound(DatasetGraph dsg, State target) {
+        return dsg.stream(Node.ANY, target.getStateNode(), Node.ANY, Node.ANY)
+                  .filter(q -> q.getObject().isURI() || q.getObject().isBlank())
+                  .filter(q -> !q.getPredicate().equals(RDF.type.asNode()) && !q.getObject()
+                                                                                .equals(target.getEntityNode()));
+    }
+
+    private static Stream<Quad> inbound(DatasetGraph dsg, State target) {
+        return dsg.stream(Node.ANY, Node.ANY, Node.ANY, target.getStateNode())
+                  .filter(q -> q.getSubject().isURI() || q.getSubject().isBlank())
+                  .filter(q -> dsg.contains(Node.ANY, q.getSubject(), RDF.type.asNode(), Node.ANY));
+
+    }
+
+    @Override
+    protected Stream<Quad> select(DataFetchingEnvironment environment, DatasetGraph dsg, State state) {
+        return Streams.concat(AbstractStateRelationshipsFetcher.outbound(dsg, state),
+                              AbstractStateRelationshipsFetcher.inbound(dsg, state));
+    }
+}

--- a/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/fetchers/telicent/graph/InstancesCountFetcher.java
+++ b/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/fetchers/telicent/graph/InstancesCountFetcher.java
@@ -12,32 +12,33 @@
  */
 package io.telicent.jena.graphql.fetchers.telicent.graph;
 
-import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
+import io.telicent.jena.graphql.schemas.telicent.graph.models.RelationshipCounts;
 import io.telicent.jena.graphql.schemas.telicent.graph.models.TelicentGraphNode;
 import org.apache.jena.graph.Node;
 import org.apache.jena.sparql.core.DatasetGraph;
 
-import java.util.List;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
- * A GraphQL {@link DataFetcher} that finds instances of a type
+ * A data fetcher that calculates the total number of instances available
  */
-public class InstancesFetcher
-        extends AbstractInstancesFetcher<List<TelicentGraphNode>> {
-
-    /**
-     * Creates a fetcher that finds all instances of a type
-     */
-    public InstancesFetcher() {
-
+public class InstancesCountFetcher extends AbstractInstancesFetcher<Integer> {
+    @Override
+    protected TelicentGraphNode getSource(DataFetchingEnvironment environment) {
+        RelationshipCounts counts = environment.getSource();
+        return counts.parent();
     }
 
     @Override
-    protected List<TelicentGraphNode> map(DataFetchingEnvironment environment, DatasetGraph dsg,
-                                          TelicentGraphNode source, Stream<Node> input) {
-        return input.map(n -> new TelicentGraphNode(n, dsg.prefixes())).collect(Collectors.toList());
+    protected Integer map(DataFetchingEnvironment environment, DatasetGraph dsg, TelicentGraphNode node,
+                          Stream<Node> input) {
+        return Math.toIntExact(input.count());
+    }
+
+    @Override
+    protected Stream<Node> applyLimitAndOffset(DataFetchingEnvironment environment, Stream<Node> stream) {
+        // Want the full count so don't apply paging
+        return stream;
     }
 }

--- a/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/fetchers/telicent/graph/LiteralsCountFetcher.java
+++ b/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/fetchers/telicent/graph/LiteralsCountFetcher.java
@@ -12,32 +12,33 @@
  */
 package io.telicent.jena.graphql.fetchers.telicent.graph;
 
-import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
+import io.telicent.jena.graphql.schemas.telicent.graph.models.RelationshipCounts;
 import io.telicent.jena.graphql.schemas.telicent.graph.models.TelicentGraphNode;
-import org.apache.jena.graph.Node;
 import org.apache.jena.sparql.core.DatasetGraph;
+import org.apache.jena.sparql.core.Quad;
 
-import java.util.List;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
- * A GraphQL {@link DataFetcher} that finds instances of a type
+ * A data fetcher that simply counts the literal properties directly attached to a node
  */
-public class InstancesFetcher
-        extends AbstractInstancesFetcher<List<TelicentGraphNode>> {
-
-    /**
-     * Creates a fetcher that finds all instances of a type
-     */
-    public InstancesFetcher() {
-
+public class LiteralsCountFetcher extends AbstractLiteralsFetcher<Integer> {
+    @Override
+    protected TelicentGraphNode getSource(DataFetchingEnvironment environment) {
+        RelationshipCounts counts = environment.getSource();
+        return counts.parent();
     }
 
     @Override
-    protected List<TelicentGraphNode> map(DataFetchingEnvironment environment, DatasetGraph dsg,
-                                          TelicentGraphNode source, Stream<Node> input) {
-        return input.map(n -> new TelicentGraphNode(n, dsg.prefixes())).collect(Collectors.toList());
+    protected Stream<Quad> applyLimitAndOffset(DataFetchingEnvironment environment, Stream<Quad> stream) {
+        // Want to get the total count so don't apply paging
+        return stream;
+    }
+
+    @Override
+    protected Integer map(DataFetchingEnvironment environment, DatasetGraph dsg, TelicentGraphNode node,
+                          Stream<Quad> input) {
+        return Math.toIntExact(input.count());
     }
 }

--- a/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/fetchers/telicent/graph/NodeTypeCountsFetcher.java
+++ b/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/fetchers/telicent/graph/NodeTypeCountsFetcher.java
@@ -12,32 +12,33 @@
  */
 package io.telicent.jena.graphql.fetchers.telicent.graph;
 
-import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
+import io.telicent.jena.graphql.schemas.telicent.graph.models.RelationshipCounts;
 import io.telicent.jena.graphql.schemas.telicent.graph.models.TelicentGraphNode;
 import org.apache.jena.graph.Node;
 import org.apache.jena.sparql.core.DatasetGraph;
 
-import java.util.List;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
- * A GraphQL {@link DataFetcher} that finds instances of a type
+ * A data fetcher that counts the {@code rdf:type}'s declared for a node
  */
-public class InstancesFetcher
-        extends AbstractInstancesFetcher<List<TelicentGraphNode>> {
-
-    /**
-     * Creates a fetcher that finds all instances of a type
-     */
-    public InstancesFetcher() {
-
+public class NodeTypeCountsFetcher extends AbstractNodeTypesFetcher<Integer> {
+    @Override
+    protected TelicentGraphNode getSource(DataFetchingEnvironment environment) {
+        RelationshipCounts counts = environment.getSource();
+        return counts.parent();
     }
 
     @Override
-    protected List<TelicentGraphNode> map(DataFetchingEnvironment environment, DatasetGraph dsg,
-                                          TelicentGraphNode source, Stream<Node> input) {
-        return input.map(n -> new TelicentGraphNode(n, dsg.prefixes())).collect(Collectors.toList());
+    protected Stream<Node> applyLimitAndOffset(DataFetchingEnvironment environment, Stream<Node> stream) {
+        // Want full count so don't apply paging
+        return stream;
+    }
+
+    @Override
+    protected Integer map(DataFetchingEnvironment environment, DatasetGraph dsg, TelicentGraphNode node,
+                          Stream<Node> input) {
+        return Math.toIntExact(input.count());
     }
 }

--- a/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/fetchers/telicent/graph/RelationshipCountsFetcher.java
+++ b/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/fetchers/telicent/graph/RelationshipCountsFetcher.java
@@ -14,51 +14,42 @@ package io.telicent.jena.graphql.fetchers.telicent.graph;
 
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
-import io.telicent.jena.graphql.execution.telicent.graph.TelicentExecutionContext;
 import io.telicent.jena.graphql.schemas.models.EdgeDirection;
-import io.telicent.jena.graphql.schemas.telicent.graph.models.Relationship;
 import io.telicent.jena.graphql.schemas.telicent.graph.models.RelationshipCounts;
 import io.telicent.jena.graphql.schemas.telicent.graph.models.TelicentGraphNode;
-import org.apache.jena.graph.Node;
 import org.apache.jena.sparql.core.DatasetGraph;
 import org.apache.jena.sparql.core.Quad;
-import org.apache.jena.system.Txn;
 
-import java.util.List;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
  * A GraphQL {@link DataFetcher} that finds the counts of incoming/outgoing relationships for a node
  */
-public class RelationshipCountsFetcher implements DataFetcher<RelationshipCounts> {
+public class RelationshipCountsFetcher extends AbstractRelationshipsFetcher<Integer> {
 
     /**
      * Creates a new relationship counts fetcher
+     * @param direction Direction of relationships to count
      */
-    public RelationshipCountsFetcher() {}
+    public RelationshipCountsFetcher(EdgeDirection direction) {
+        super(direction);
+    }
 
     @Override
-    public RelationshipCounts get(DataFetchingEnvironment environment) {
-        TelicentExecutionContext context = environment.getLocalContext();
-        DatasetGraph dsg = context.getDatasetGraph();
-        TelicentGraphNode target = environment.getSource();
-
-        return Txn.calculateRead(dsg, () -> countRelationships(dsg, target));
+    protected TelicentGraphNode getSource(DataFetchingEnvironment environment) {
+        RelationshipCounts counts = environment.getSource();
+        return counts.parent();
     }
 
-    private RelationshipCounts countRelationships(DatasetGraph dsg, TelicentGraphNode target) {
-        return new RelationshipCounts(stream(dsg, target, EdgeDirection.IN), stream(dsg, target, EdgeDirection.OUT));
+    @Override
+    protected Integer map(DataFetchingEnvironment environment, DatasetGraph dsg, TelicentGraphNode node,
+                          Stream<Quad> input) {
+        return Math.toIntExact(input.count());
     }
 
-    private int stream(DatasetGraph dsg, TelicentGraphNode target, EdgeDirection direction) {
-        return Math.toIntExact(streamTargets(dsg, target, direction).filter(n -> n.isURI() || n.isBlank()).count());
-    }
-
-    private static Stream<Node> streamTargets(DatasetGraph dsg, TelicentGraphNode target, EdgeDirection direction) {
-        return switch (direction) {
-            case OUT -> dsg.stream(Node.ANY, target.getNode(), Node.ANY, Node.ANY).map(Quad::getObject);
-            case IN -> dsg.stream(Node.ANY, Node.ANY, Node.ANY, target.getNode()).map(Quad::getSubject);
-        };
+    @Override
+    protected Stream<Quad> applyLimitAndOffset(DataFetchingEnvironment environment, Stream<Quad> stream) {
+        // Want the full count so don't apply paging
+        return stream;
     }
 }

--- a/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/fetchers/telicent/graph/RelationshipCountsPlaceholderFetcher.java
+++ b/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/fetchers/telicent/graph/RelationshipCountsPlaceholderFetcher.java
@@ -14,30 +14,21 @@ package io.telicent.jena.graphql.fetchers.telicent.graph;
 
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
+import io.telicent.jena.graphql.schemas.telicent.graph.models.RelationshipCounts;
 import io.telicent.jena.graphql.schemas.telicent.graph.models.TelicentGraphNode;
-import org.apache.jena.graph.Node;
-import org.apache.jena.sparql.core.DatasetGraph;
-
-import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
- * A GraphQL {@link DataFetcher} that finds instances of a type
+ * A placeholder fetcher that returns a simple record class with a reference back to the parent node
+ * <p>
+ * This is needed because GraphQL Java doesn't allow a non-scalar typed field to have an empty value (unless explicitly
+ * nullable), and we need to have a placeholder object present so that the fetchers that actually compute the counts
+ * can get access to the parent {@link TelicentGraphNode} they need to find the things to count.
+ * </p>
  */
-public class InstancesFetcher
-        extends AbstractInstancesFetcher<List<TelicentGraphNode>> {
-
-    /**
-     * Creates a fetcher that finds all instances of a type
-     */
-    public InstancesFetcher() {
-
-    }
-
+public class RelationshipCountsPlaceholderFetcher implements DataFetcher<RelationshipCounts> {
     @Override
-    protected List<TelicentGraphNode> map(DataFetchingEnvironment environment, DatasetGraph dsg,
-                                          TelicentGraphNode source, Stream<Node> input) {
-        return input.map(n -> new TelicentGraphNode(n, dsg.prefixes())).collect(Collectors.toList());
+    public RelationshipCounts get(DataFetchingEnvironment environment) throws Exception {
+        TelicentGraphNode source = environment.getSource();
+        return new RelationshipCounts(source);
     }
 }

--- a/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/fetchers/telicent/graph/RelationshipsFetcher.java
+++ b/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/fetchers/telicent/graph/RelationshipsFetcher.java
@@ -14,14 +14,11 @@ package io.telicent.jena.graphql.fetchers.telicent.graph;
 
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
-import io.telicent.jena.graphql.execution.telicent.graph.TelicentExecutionContext;
 import io.telicent.jena.graphql.schemas.telicent.graph.models.TelicentGraphNode;
 import io.telicent.jena.graphql.schemas.telicent.graph.models.Relationship;
 import io.telicent.jena.graphql.schemas.models.EdgeDirection;
-import org.apache.jena.graph.Node;
 import org.apache.jena.sparql.core.DatasetGraph;
 import org.apache.jena.sparql.core.Quad;
-import org.apache.jena.system.Txn;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -30,9 +27,8 @@ import java.util.stream.Stream;
 /**
  * A GraphQL {@link DataFetcher} that finds the incoming/outgoing relationships for a node
  */
-public class RelationshipsFetcher implements DataFetcher<List<Relationship>> {
-
-    private final EdgeDirection direction;
+public class RelationshipsFetcher
+        extends AbstractRelationshipsFetcher<List<Relationship>> {
 
     /**
      * Creates a new relationship fetcher
@@ -40,35 +36,16 @@ public class RelationshipsFetcher implements DataFetcher<List<Relationship>> {
      * @param direction Edge direction
      */
     public RelationshipsFetcher(EdgeDirection direction) {
-        this.direction = direction;
+        super(direction);
     }
 
     @Override
-    public List<Relationship> get(DataFetchingEnvironment environment) {
-        TelicentExecutionContext context = environment.getLocalContext();
-        DatasetGraph dsg = context.getDatasetGraph();
-        TelicentGraphNode target = environment.getSource();
-
-        return Txn.calculateRead(dsg, () -> findRelationships(dsg, target));
+    protected List<Relationship> map(DataFetchingEnvironment environment, DatasetGraph dsg, TelicentGraphNode source,
+                                     Stream<Quad> input) {
+        return input.map(q -> new Relationship(new TelicentGraphNode(q.getSubject(), dsg.prefixes()),
+                                               new TelicentGraphNode(q.getPredicate(), dsg.prefixes()),
+                                               new TelicentGraphNode(q.getObject(), dsg.prefixes())))
+                    .collect(Collectors.toList());
     }
 
-    private List<Relationship> findRelationships(DatasetGraph dsg, TelicentGraphNode target) {
-        return stream(dsg, target)
-                .map(q -> new Relationship(new TelicentGraphNode(q.getSubject(), dsg.prefixes()),
-                                           new TelicentGraphNode(q.getPredicate(), dsg.prefixes()),
-                                           new TelicentGraphNode(q.getObject(), dsg.prefixes())))
-                .collect(Collectors.toList());
-    }
-
-    private Stream<Quad> stream(DatasetGraph dsg, TelicentGraphNode target) {
-        // NB - We filter() because we only care about relationships to other nodes, not literals, the filter is
-        //      different depending on the edge direction as it's the target node we care about, which is either the
-        //      object for OUT relationships, or the subject for IN relationships
-        return switch (this.direction) {
-            case OUT -> dsg.stream(Node.ANY, target.getNode(), Node.ANY, Node.ANY)
-                           .filter(q -> q.getObject().isURI() || q.getObject().isBlank());
-            case IN -> dsg.stream(Node.ANY, Node.ANY, Node.ANY, target.getNode())
-                          .filter(q -> q.getSubject().isURI() || q.getSubject().isBlank());
-        };
-    }
 }

--- a/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/fetchers/telicent/graph/StateRelationshipCountsFetcher.java
+++ b/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/fetchers/telicent/graph/StateRelationshipCountsFetcher.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (C) Telicent Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.telicent.jena.graphql.fetchers.telicent.graph;
+
+import graphql.schema.DataFetchingEnvironment;
+import io.telicent.jena.graphql.schemas.telicent.graph.models.State;
+import io.telicent.jena.graphql.schemas.telicent.graph.models.StateRelationshipCounts;
+import org.apache.jena.sparql.core.DatasetGraph;
+import org.apache.jena.sparql.core.Quad;
+
+import java.util.stream.Stream;
+
+/**
+ * A data fetcher that counts the available relationships for a state
+ */
+public class StateRelationshipCountsFetcher extends AbstractStateRelationshipsFetcher<Integer> {
+    @Override
+    protected State getSource(DataFetchingEnvironment environment) {
+        StateRelationshipCounts counts = environment.getSource();
+        return counts.parent();
+    }
+
+    @Override
+    protected Stream<Quad> applyLimitAndOffset(DataFetchingEnvironment environment, Stream<Quad> stream) {
+        // Want total count so don't apply paging
+        return stream;
+    }
+
+    @Override
+    protected Integer map(DataFetchingEnvironment environment, DatasetGraph dsg, State state, Stream<Quad> input) {
+        return Math.toIntExact(input.count());
+    }
+}

--- a/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/fetchers/telicent/graph/StateRelationshipCountsPlaceholderFetcher.java
+++ b/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/fetchers/telicent/graph/StateRelationshipCountsPlaceholderFetcher.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (C) Telicent Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.telicent.jena.graphql.fetchers.telicent.graph;
+
+import graphql.schema.DataFetcher;
+import graphql.schema.DataFetchingEnvironment;
+import io.telicent.jena.graphql.schemas.telicent.graph.models.State;
+import io.telicent.jena.graphql.schemas.telicent.graph.models.StateRelationshipCounts;
+
+/**
+ * A placeholder fetcher that returns a simple record class with a reference back to the parent state
+ * <p>
+ * This is needed because GraphQL Java doesn't allow a non-scalar typed field to have an empty value (unless explicitly
+ * nullable), and we need to have a placeholder object present so that the fetchers that actually compute the counts can
+ * get access to the parent {@link State} they need to find the things to count.
+ * </p>
+ */
+public class StateRelationshipCountsPlaceholderFetcher implements DataFetcher<StateRelationshipCounts> {
+    @Override
+    public StateRelationshipCounts get(DataFetchingEnvironment environment) throws Exception {
+        State source = environment.getSource();
+        return new StateRelationshipCounts(source);
+    }
+}

--- a/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/fetchers/telicent/graph/StateRelationshipsFetcher.java
+++ b/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/fetchers/telicent/graph/StateRelationshipsFetcher.java
@@ -12,16 +12,13 @@
  */
 package io.telicent.jena.graphql.fetchers.telicent.graph;
 
-import graphql.com.google.common.collect.Streams;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
 import io.telicent.jena.graphql.schemas.telicent.graph.models.TelicentGraphNode;
 import io.telicent.jena.graphql.schemas.telicent.graph.models.NonDirectionalRelationship;
 import io.telicent.jena.graphql.schemas.telicent.graph.models.State;
-import org.apache.jena.graph.Node;
 import org.apache.jena.sparql.core.DatasetGraph;
 import org.apache.jena.sparql.core.Quad;
-import org.apache.jena.vocabulary.RDF;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -31,18 +28,13 @@ import java.util.stream.Stream;
  * A GraphQL {@link DataFetcher} that finds the relationships for a state
  */
 public class StateRelationshipsFetcher
-        extends AbstractLimitOffsetPagingFetcher<State, Quad, List<NonDirectionalRelationship>> {
+        extends AbstractStateRelationshipsFetcher<List<NonDirectionalRelationship>> {
 
     /**
      * Creates a new fetcher that finds the relationships involving states
      */
     public StateRelationshipsFetcher() {
 
-    }
-
-    @Override
-    protected Stream<Quad> select(DataFetchingEnvironment environment, DatasetGraph dsg, State state) {
-        return Streams.concat(outbound(dsg, state), inbound(dsg, state));
     }
 
     @Override
@@ -53,20 +45,6 @@ public class StateRelationshipsFetcher
                                                                      source.getStateNode().equals(q.getSubject()) ?
                                                                      q.getObject() : q.getSubject(), dsg.prefixes())))
                     .collect(Collectors.toList());
-    }
-
-    private static Stream<Quad> outbound(DatasetGraph dsg, State target) {
-        return dsg.stream(Node.ANY, target.getStateNode(), Node.ANY, Node.ANY)
-                  .filter(q -> q.getObject().isURI() || q.getObject().isBlank())
-                  .filter(q -> !q.getPredicate().equals(RDF.type.asNode()) && !q.getObject()
-                                                                                .equals(target.getEntityNode()));
-    }
-
-    private static Stream<Quad> inbound(DatasetGraph dsg, State target) {
-        return dsg.stream(Node.ANY, Node.ANY, Node.ANY, target.getStateNode())
-                  .filter(q -> q.getSubject().isURI() || q.getSubject().isBlank())
-                  .filter(q -> dsg.contains(Node.ANY, q.getSubject(), RDF.type.asNode(), Node.ANY));
-
     }
 
 }

--- a/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/fetchers/telicent/graph/StateRelationshipsFetcher.java
+++ b/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/fetchers/telicent/graph/StateRelationshipsFetcher.java
@@ -15,14 +15,12 @@ package io.telicent.jena.graphql.fetchers.telicent.graph;
 import graphql.com.google.common.collect.Streams;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
-import io.telicent.jena.graphql.execution.telicent.graph.TelicentExecutionContext;
 import io.telicent.jena.graphql.schemas.telicent.graph.models.TelicentGraphNode;
 import io.telicent.jena.graphql.schemas.telicent.graph.models.NonDirectionalRelationship;
 import io.telicent.jena.graphql.schemas.telicent.graph.models.State;
 import org.apache.jena.graph.Node;
 import org.apache.jena.sparql.core.DatasetGraph;
 import org.apache.jena.sparql.core.Quad;
-import org.apache.jena.system.Txn;
 import org.apache.jena.vocabulary.RDF;
 
 import java.util.List;
@@ -32,7 +30,8 @@ import java.util.stream.Stream;
 /**
  * A GraphQL {@link DataFetcher} that finds the relationships for a state
  */
-public class StateRelationshipsFetcher implements DataFetcher<List<NonDirectionalRelationship>> {
+public class StateRelationshipsFetcher
+        extends AbstractLimitOffsetPagingFetcher<State, Quad, List<NonDirectionalRelationship>> {
 
     /**
      * Creates a new fetcher that finds the relationships involving states
@@ -42,39 +41,32 @@ public class StateRelationshipsFetcher implements DataFetcher<List<NonDirectiona
     }
 
     @Override
-    public List<NonDirectionalRelationship> get(DataFetchingEnvironment environment) {
-        TelicentExecutionContext context = environment.getLocalContext();
-        DatasetGraph dsg = context.getDatasetGraph();
-        State target = environment.getSource();
-
-        return Txn.calculateRead(dsg, () -> Streams.concat(outboundRelationships(dsg, target),
-                                                           inboundRelationships(dsg, target))
-                                                   .collect(Collectors.toList()));
+    protected Stream<Quad> select(DataFetchingEnvironment environment, DatasetGraph dsg, State state) {
+        return Streams.concat(outbound(dsg, state), inbound(dsg, state));
     }
 
-    private static Stream<NonDirectionalRelationship> inboundRelationships(DatasetGraph dsg, State target) {
-        return inbound(dsg, target).filter(q -> q.getSubject().isURI() || q.getSubject().isBlank())
-                                   .map(q -> new NonDirectionalRelationship(
-                                           new TelicentGraphNode(q.getPredicate(), dsg.prefixes()),
-                                           new TelicentGraphNode(q.getSubject(), dsg.prefixes())));
-    }
-
-    private static Stream<NonDirectionalRelationship> outboundRelationships(DatasetGraph dsg, State target) {
-        return outbound(dsg, target).filter(q -> q.getObject().isURI() || q.getObject().isBlank())
-                                    .map(q -> new NonDirectionalRelationship(
-                                            new TelicentGraphNode(q.getPredicate(), dsg.prefixes()),
-                                            new TelicentGraphNode(q.getObject(), dsg.prefixes())));
+    @Override
+    protected List<NonDirectionalRelationship> map(DataFetchingEnvironment environment, DatasetGraph dsg, State source,
+                                                   Stream<Quad> input) {
+        return input.map(q -> new NonDirectionalRelationship(new TelicentGraphNode(q.getPredicate(), dsg.prefixes()),
+                                                             new TelicentGraphNode(
+                                                                     source.getStateNode().equals(q.getSubject()) ?
+                                                                     q.getObject() : q.getSubject(), dsg.prefixes())))
+                    .collect(Collectors.toList());
     }
 
     private static Stream<Quad> outbound(DatasetGraph dsg, State target) {
         return dsg.stream(Node.ANY, target.getStateNode(), Node.ANY, Node.ANY)
+                  .filter(q -> q.getObject().isURI() || q.getObject().isBlank())
                   .filter(q -> !q.getPredicate().equals(RDF.type.asNode()) && !q.getObject()
                                                                                 .equals(target.getEntityNode()));
     }
 
     private static Stream<Quad> inbound(DatasetGraph dsg, State target) {
         return dsg.stream(Node.ANY, Node.ANY, Node.ANY, target.getStateNode())
+                  .filter(q -> q.getSubject().isURI() || q.getSubject().isBlank())
                   .filter(q -> dsg.contains(Node.ANY, q.getSubject(), RDF.type.asNode(), Node.ANY));
+
     }
 
 }

--- a/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/schemas/telicent/graph/TelicentGraphSchema.java
+++ b/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/schemas/telicent/graph/TelicentGraphSchema.java
@@ -22,6 +22,15 @@ import java.io.IOException;
  */
 public class TelicentGraphSchema {
 
+    /**
+     * Default limit applied to fields that support paging
+     */
+    public static final long DEFAULT_LIMIT = 50;
+    /**
+     * Maximum permitted limit applied to fields that support paging
+     */
+    public static final long MAX_LIMIT = 250;
+
     private TelicentGraphSchema() {}
     /**
      * The classpath resource that contains the GraphQL schema file
@@ -190,14 +199,9 @@ public class TelicentGraphSchema {
      */
     public static final String FIELD_RELATIONS = "relations";
     /**
-     * In field
+     * Value field
      */
-    public static final String FIELD_IN = "in";
-    /**
-     * Out field
-     */
-    public static final String FIELD_OUT = "out";
-
+    public static final String FIELD_VALUE = "value";
     /**
      * Extension property used to supply the users authentication token that may be passed on by some
      * {@link graphql.schema.DataFetcher} instances when they need to query other Telicent services

--- a/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/schemas/telicent/graph/TelicentGraphSchema.java
+++ b/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/schemas/telicent/graph/TelicentGraphSchema.java
@@ -61,7 +61,7 @@ public class TelicentGraphSchema {
     /**
      * Relationship counts type
      */
-    public static final String TYPE_RELATIONSHIP_COUNTS = "RelCounts";
+    public static final String TYPE_RELATIONSHIP_COUNTS = "NodeRelCounts";
     /**
      * Property type
      */
@@ -70,6 +70,10 @@ public class TelicentGraphSchema {
      * State type
      */
     public static final String TYPE_STATE = "State";
+    /**
+     * State relationship counts type
+     */
+    public static final String TYPE_STATE_RELATIONSHIP_COUNTS = "StateRelCounts";
     /**
      * Search results type
      */

--- a/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/schemas/telicent/graph/models/RelationshipCounts.java
+++ b/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/schemas/telicent/graph/models/RelationshipCounts.java
@@ -13,41 +13,9 @@
 package io.telicent.jena.graphql.schemas.telicent.graph.models;
 
 /**
- * Holds information about relationship counts
- * <p>
- * This is intentionally an object so we can potentially augment this with further fields in the future if we need to.
- * </p>
+ * Placeholder for relationship counts
+ *
+ * @param parent Parent node
  */
-public class RelationshipCounts {
-
-    private final int in, out;
-
-    /**
-     * Creates new relationship counts
-     *
-     * @param in  Count of incoming relationships
-     * @param out Count of outgoing relationships
-     */
-    public RelationshipCounts(int in, int out) {
-        this.in = in;
-        this.out = out;
-    }
-
-    /**
-     * Gets the count of incoming relationships
-     *
-     * @return Incoming relationships count
-     */
-    public int getIn() {
-        return in;
-    }
-
-    /**
-     * Gets the count of outgoing relationships
-     *
-     * @return Outgoing relationships count
-     */
-    public int getOut() {
-        return out;
-    }
+public record RelationshipCounts(TelicentGraphNode parent) {
 }

--- a/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/schemas/telicent/graph/models/StateRelationshipCounts.java
+++ b/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/schemas/telicent/graph/models/StateRelationshipCounts.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright (C) Telicent Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.telicent.jena.graphql.schemas.telicent.graph.models;
+
+/**
+ * Placeholder for state relationship counts
+ *
+ * @param parent Parent node
+ */
+public record StateRelationshipCounts(State parent) {
+}

--- a/telicent-graph-schema/src/main/resources/io/telicent/jena/graphql/schemas/telicent/graph/ies.graphqls
+++ b/telicent-graph-schema/src/main/resources/io/telicent/jena/graphql/schemas/telicent/graph/ies.graphqls
@@ -1,26 +1,26 @@
 type Node {
-    id: ID! #Used if you want client-side caching, but will return the same string as uri
-    uri: String! #The uri of the resource
-    uriHash: String! @deprecated #A SHA1 hash of the uri
-    shortUri: String! #If a shortened (namespace prefixed) form of the uri is available, otherwise returns full uri
-    types(limit: Int = 50, offset: Int = 1): [Node]! #An array of types for the Node - i.e. the classes it is an instance of.
-    properties(limit: Int = 50, offset: Int = 1): [Property]! #An array of literal properties of the Node
-    outRels(limit: Int = 50, offset: Int = 1): [Rel]! #An array of Rels where the current Node is in the domain position
-    inRels(limit: Int = 50, offset: Int = 1): [Rel]! #An array of Rels where the current Node is in the range position
-    relCounts: RelCounts!
-    instances(limit: Int = 50, offset: Int = 1): [Node] #If the node is a class, this will return an array of its instances
+    id: ID! # Used if you want client-side caching, but will return the same string as uri
+    uri: String! # The uri of the resource
+    uriHash: String! @deprecated # A SHA1 hash of the uri
+    shortUri: String! # If a shortened (namespace prefixed) form of the uri is available, otherwise returns full uri
+    types(limit: Int = 50, offset: Int = 1): [Node]! # An array of types for the Node - i.e. the classes it is an instance of.
+    properties(limit: Int = 50, offset: Int = 1): [Property]! # An array of literal properties of the Node
+    outRels(limit: Int = 50, offset: Int = 1): [Rel]! # An array of Rels where the current Node is in the domain position
+    inRels(limit: Int = 50, offset: Int = 1): [Rel]! # An array of Rels where the current Node is in the range position
+    relCounts: NodeRelCounts! # Relationship counts information
+    instances(limit: Int = 50, offset: Int = 1): [Node] # If the node is a class, this will return an array of its instances
 }
 
-type Rel { #A subject-predicate-object statement
-    id: ID! #A (sorta) unique ID made from hashing (SHA1) the "<subject> <predicate> <object>" string
-    domain: Node! #AKA subject
+type Rel { # A subject-predicate-object statement
+    id: ID! # A (sorta) unique ID made from hashing (SHA1) the "<subject> <predicate> <object>" string
+    domain: Node! # AKA subject
     domain_id: String!
-    predicate: String! #AKA property
+    predicate: String! # AKA property
     range_id: String!
-    range: Node! #AKA object
+    range: Node! # AKA object
 }
 
-type RelCounts {
+type NodeRelCounts { # Counts of relationships available for a Node
     inRels: Int
     outRels: Int
     properties: Int
@@ -43,6 +43,11 @@ type State {
     end: String
     period: String
     relations(limit: Int = 50, offset: Int = 1): [NonDirectionalRel]!
+    relCounts: StateRelCounts!
+}
+
+type StateRelCounts {
+    relations: Int
 }
 
 type NonDirectionalRel {

--- a/telicent-graph-schema/src/main/resources/io/telicent/jena/graphql/schemas/telicent/graph/ies.graphqls
+++ b/telicent-graph-schema/src/main/resources/io/telicent/jena/graphql/schemas/telicent/graph/ies.graphqls
@@ -3,12 +3,12 @@ type Node {
     uri: String! #The uri of the resource
     uriHash: String! @deprecated #A SHA1 hash of the uri
     shortUri: String! #If a shortened (namespace prefixed) form of the uri is available, otherwise returns full uri
-    types: [Node]! #An array of types for the Node - i.e. the classes it is an instance of.
-    properties: [Property]! #An array of literal properties of the Node
-    outRels: [Rel]! #An array of Rels where the current Node is in the domain position
-    inRels: [Rel]! #An array of Rels where the current Node is in the range position
+    types(limit: Int = 50, offset: Int = 1): [Node]! #An array of types for the Node - i.e. the classes it is an instance of.
+    properties(limit: Int = 50, offset: Int = 1): [Property]! #An array of literal properties of the Node
+    outRels(limit: Int = 50, offset: Int = 1): [Rel]! #An array of Rels where the current Node is in the domain position
+    inRels(limit: Int = 50, offset: Int = 1): [Rel]! #An array of Rels where the current Node is in the range position
     relCounts: RelCounts!
-    instances: [Node] #If the node is a class, this will return an array of its instances
+    instances(limit: Int = 50, offset: Int = 1): [Node] #If the node is a class, this will return an array of its instances
 }
 
 type Rel { #A subject-predicate-object statement
@@ -21,8 +21,11 @@ type Rel { #A subject-predicate-object statement
 }
 
 type RelCounts {
-    in: Int
-    out: Int
+    inRels: Int
+    outRels: Int
+    properties: Int
+    types: Int
+    instances: Int
 }
 
 type Property { #A literal property
@@ -39,7 +42,7 @@ type State {
     start: String
     end: String
     period: String
-    relations: [NonDirectionalRel]!
+    relations(limit: Int = 50, offset: Int = 1): [NonDirectionalRel]!
 }
 
 type NonDirectionalRel {

--- a/telicent-graph-schema/src/test/java/io/telicent/jena/graphql/fetchers/telicent/graph/AbstractFetcherTests.java
+++ b/telicent-graph-schema/src/test/java/io/telicent/jena/graphql/fetchers/telicent/graph/AbstractFetcherTests.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (C) Telicent Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.telicent.jena.graphql.fetchers.telicent.graph;
+
+import graphql.schema.DataFetchingEnvironment;
+import graphql.schema.DataFetchingEnvironmentImpl;
+import io.telicent.jena.graphql.execution.telicent.graph.TelicentExecutionContext;
+import org.apache.jena.sparql.core.DatasetGraph;
+import org.apache.jena.sys.JenaSystem;
+
+public class AbstractFetcherTests {
+
+    static {
+        JenaSystem.init();
+    }
+
+    protected static <T> DataFetchingEnvironment prepareFetchingEnvironment(DatasetGraph dsg, T source) {
+        TelicentExecutionContext context = new TelicentExecutionContext(dsg, "");
+        return DataFetchingEnvironmentImpl
+                .newDataFetchingEnvironment()
+                .localContext(context)
+                .source(source)
+                .build();
+    }
+}

--- a/telicent-graph-schema/src/test/java/io/telicent/jena/graphql/fetchers/telicent/graph/TestLiteralsFetcher.java
+++ b/telicent-graph-schema/src/test/java/io/telicent/jena/graphql/fetchers/telicent/graph/TestLiteralsFetcher.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright (C) Telicent Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.telicent.jena.graphql.fetchers.telicent.graph;
+
+import graphql.schema.DataFetcher;
+import graphql.schema.DataFetchingEnvironment;
+import io.telicent.jena.graphql.schemas.telicent.graph.TelicentGraphSchema;
+import io.telicent.jena.graphql.schemas.telicent.graph.models.LiteralProperty;
+import io.telicent.jena.graphql.schemas.telicent.graph.models.RelationshipCounts;
+import io.telicent.jena.graphql.schemas.telicent.graph.models.TelicentGraphNode;
+import org.apache.jena.datatypes.xsd.XSDDatatype;
+import org.apache.jena.graph.Node;
+import org.apache.jena.sparql.core.DatasetGraph;
+import org.apache.jena.sparql.core.DatasetGraphFactory;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.List;
+
+import static org.apache.jena.graph.NodeFactory.*;
+
+public class TestLiteralsFetcher extends AbstractFetcherTests {
+
+    @Test
+    public void givenGraphWithManyLiterals_whenFetchingProperties_thenPagingIsApplied() throws Exception {
+        // Given
+        LiteralPropertiesFetcher fetcher = new LiteralPropertiesFetcher();
+        DatasetGraph dsg = DatasetGraphFactory.create();
+        Node graph = createURI("graph");
+        Node subject = createURI("subject");
+        generateManyLiterals(dsg, graph, subject);
+        DataFetchingEnvironment environment = prepareFetchingEnvironment(dsg, new TelicentGraphNode(subject, null));
+
+        // When
+        List<LiteralProperty> literals = fetcher.get(environment);
+
+        // Then
+        Assert.assertNotNull(literals);
+        Assert.assertEquals(literals.size(), TelicentGraphSchema.DEFAULT_LIMIT);
+    }
+
+    @Test
+    public void givenGraphWithManyLiterals_whenCountingProperties_thenCountIsCorrect() throws Exception {
+        // Given
+        DataFetcher<Integer> fetcher = new LiteralsCountFetcher();
+        DatasetGraph dsg = DatasetGraphFactory.create();
+        Node graph = createURI("graph");
+        Node subject = createURI("subject");
+        generateManyLiterals(dsg, graph, subject);
+        DataFetchingEnvironment environment =
+                prepareFetchingEnvironment(dsg, new RelationshipCounts(new TelicentGraphNode(subject, null)));
+
+        // When
+        Integer count = fetcher.get(environment);
+
+        // Then
+        Assert.assertNotNull(count);
+        Assert.assertEquals(count, 1_000);
+    }
+
+    private static void generateManyLiterals(DatasetGraph dsg, Node graph, Node subject) {
+        Node predicate = createURI("predicate");
+        for (int i = 0; i < 1_000; i++) {
+            dsg.add(graph, subject, predicate, createLiteralDT(Integer.toString(i), XSDDatatype.XSDinteger));
+        }
+    }
+
+}

--- a/telicent-graph-schema/src/test/java/io/telicent/jena/graphql/fetchers/telicent/graph/TestStateRelationshipsFetcher.java
+++ b/telicent-graph-schema/src/test/java/io/telicent/jena/graphql/fetchers/telicent/graph/TestStateRelationshipsFetcher.java
@@ -31,7 +31,7 @@ import static org.apache.jena.graph.NodeFactory.*;
 
 public class TestStateRelationshipsFetcher {
     @Test
-    public void test_get_literalNode() {
+    public void test_get_literalNode() throws Exception {
         // given
         StateRelationshipsFetcher fetcher = new StateRelationshipsFetcher();
         DatasetGraph dsg  = DatasetGraphFactory.create();
@@ -53,7 +53,7 @@ public class TestStateRelationshipsFetcher {
     }
 
     @Test
-    public void test_get_blankNode() {
+    public void test_get_blankNode() throws Exception {
         // given
         StateRelationshipsFetcher fetcher = new StateRelationshipsFetcher();
         DatasetGraph dsg  = DatasetGraphFactory.create();
@@ -75,7 +75,7 @@ public class TestStateRelationshipsFetcher {
     }
 
     @Test
-    public void test_get_uriNode_outbound() {
+    public void test_get_uriNode_outbound() throws Exception {
         // given
         StateRelationshipsFetcher fetcher = new StateRelationshipsFetcher();
         DatasetGraph dsg  = DatasetGraphFactory.create();
@@ -97,7 +97,7 @@ public class TestStateRelationshipsFetcher {
     }
 
     @Test
-    public void test_get_uriNode_inbound() {
+    public void test_get_uriNode_inbound() throws Exception {
         // given
         StateRelationshipsFetcher fetcher = new StateRelationshipsFetcher();
         DatasetGraph dsg  = DatasetGraphFactory.create();

--- a/telicent-graph-schema/src/test/resources/queries/telicent/graph/instances.graphql
+++ b/telicent-graph-schema/src/test/resources/queries/telicent/graph/instances.graphql
@@ -1,11 +1,14 @@
-query {
+query($limit : Int = 10, $offset : Int = 1) {
     node(uri: "http://ies.data.gov.uk/ontology/ies4#Person") {
         id
         uri
         shortUri
-        instances {
+        instances(limit: $limit, offset: $offset) {
             uri
             shortUri
+        }
+        relCounts {
+            instances
         }
     }
 }

--- a/telicent-graph-schema/src/test/resources/queries/telicent/graph/single-node-with-paging.graphql
+++ b/telicent-graph-schema/src/test/resources/queries/telicent/graph/single-node-with-paging.graphql
@@ -1,22 +1,24 @@
-query {
+query($limit: Int, $offset: Int) {
     node(uri: "https://starwars.com#person_Obi-WanKenobi") {
         id
         uri
         shortUri
-        properties {
+        properties(limit: $limit, offset: $offset) {
             predicate
             value
             datatype
             language
         }
-        inRels {
+        inRels(limit: $limit, offset: $offset) {
+            id
             domain {
                 uri
             }
             domain_id
             predicate
         }
-        outRels {
+        outRels(limit: $limit, offset: $offset) {
+            id
             predicate
             range {
                 uri
@@ -26,10 +28,11 @@ query {
         relCounts {
             inRels
             outRels
-            properties
             instances
+            properties
         }
-        instances {
+        instances(limit: $limit, offset: $offset) {
+            id
             uri
         }
     }


### PR DESCRIPTION
For `Node` and `State` fields that return a list add `limit` and `offset` arguments, and apply those in the `DataFetcher` implementations so that those fields are automatically paginated.

For comparison using the example Tripoli queries from TELFE-1159 here are the respective response sizes:

![Screenshot 2025-05-14 at 14 56 02](https://github.com/user-attachments/assets/91a9854f-2fd4-48d2-b42f-8c7ec93cc96b)

With default pagination settings the single node query response size drops from 264k to 13k, and the multi nodes query response size drops from 14M to 5.9M

# Outstanding Work

- [x] Expand test coverage to test pagination on other fields to which support has been added, currently only `inRels` and `outRels` fields are tested
- [ ] Discuss whether default limit should be lower than `50` and if so adjust accordingly
- [x] Expand `relCounts` field (added in #66) to expose counts for all pageable fields i.e. `types`, `properties` and `instances`
- [x] Updated documentation
- [x] Updated CHANGELOG