### PR TITLE
Relationship Facet computation support (CORE-801)

### DIFF
--- a/graphql-jena-core/src/test/java/io/telicent/jena/graphql/execution/AbstractExecutionTests.java
+++ b/graphql-jena-core/src/test/java/io/telicent/jena/graphql/execution/AbstractExecutionTests.java
@@ -102,6 +102,18 @@ public class AbstractExecutionTests {
     }
 
     /**
+     * Verifies that executing the given request generates a result that contains errors
+     * @param execution Execution to run the query against
+     * @param request Query request
+     * @return Execution results
+     */
+    protected static ExecutionResult verifyExecutionErrors(GraphQLExecutor execution, GraphQLRequest request) {
+        ExecutionResult result = execution.execute(request);
+        Assert.assertFalse(result.getErrors().isEmpty());
+        return result;
+    }
+
+    /**
      * Verifies that the given query is valid
      *
      * @param execution Execution to validate the query against
@@ -121,7 +133,7 @@ public class AbstractExecutionTests {
      * @return Validation result
      */
     protected static ParseAndValidateResult verifyValidationSuccess(GraphQLExecutor execution, String query,
-                                                     Map<String, Object> variables) {
+                                                                    Map<String, Object> variables) {
         return verifyValidationSuccess(execution, query, variables, Collections.emptyMap());
     }
 
@@ -135,7 +147,8 @@ public class AbstractExecutionTests {
      * @return Validation result
      */
     protected static ParseAndValidateResult verifyValidationSuccess(GraphQLExecutor execution, String query,
-                                                                    Map<String, Object> variables, Map<String,Object> extensions) {
+                                                                    Map<String, Object> variables,
+                                                                    Map<String, Object> extensions) {
         ParseAndValidateResult result = execution.validate(query, "test", variables, extensions);
         Assert.assertFalse(result.isFailure());
         Assert.assertTrue(result.getErrors().isEmpty());
@@ -165,6 +178,7 @@ public class AbstractExecutionTests {
                                                                     Map<String, Object> variables) {
         return verifyValidationFailure(execution, query, variables, Collections.emptyMap());
     }
+
     /**
      * Verifies that the given query is invalid
      *
@@ -175,7 +189,8 @@ public class AbstractExecutionTests {
      * @return Validation result
      */
     protected static ParseAndValidateResult verifyValidationFailure(GraphQLExecutor execution, String query,
-                                                                    Map<String, Object> variables, Map<String,Object> extensions) {
+                                                                    Map<String, Object> variables,
+                                                                    Map<String, Object> extensions) {
         ParseAndValidateResult result = execution.validate(query, "test", variables, extensions);
         Assert.assertTrue(result.isFailure());
         Assert.assertFalse(result.getErrors().isEmpty());

--- a/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/execution/telicent/graph/TelicentGraphExecutor.java
+++ b/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/execution/telicent/graph/TelicentGraphExecutor.java
@@ -21,7 +21,6 @@ import io.telicent.jena.graphql.fetchers.telicent.graph.*;
 import io.telicent.jena.graphql.schemas.models.EdgeDirection;
 import io.telicent.jena.graphql.schemas.telicent.graph.TelicentGraphSchema;
 import io.telicent.jena.graphql.schemas.telicent.graph.models.SearchType;
-import io.telicent.jena.graphql.schemas.telicent.graph.models.TelicentGraphNode;
 import org.apache.jena.sparql.core.DatasetGraph;
 
 import java.io.IOException;
@@ -55,6 +54,7 @@ public class TelicentGraphExecutor extends AbstractDatasetExecutor {
     @Override
     protected RuntimeWiring.Builder buildRuntimeWiring() {
         final StatePeriodFetcher periodFetcher = new StatePeriodFetcher();
+        final NodePlaceholderFetcher nodePlaceholderFetcher = new NodePlaceholderFetcher();
         NaturalEnumValuesProvider<SearchType> nodeKinds = new NaturalEnumValuesProvider<>(SearchType.class);
         //@formatter:off
         return RuntimeWiring.newRuntimeWiring()
@@ -72,7 +72,8 @@ public class TelicentGraphExecutor extends AbstractDatasetExecutor {
                                         .dataFetcher(TelicentGraphSchema.FIELD_INBOUND_RELATIONSHIPS, new RelationshipsFetcher(EdgeDirection.IN))
                                         .dataFetcher(TelicentGraphSchema.FIELD_OUTBOUND_RELATIONSHIPS, new RelationshipsFetcher(EdgeDirection.OUT))
                                         .dataFetcher(TelicentGraphSchema.FIELD_INSTANCES, new InstancesFetcher())
-                                        .dataFetcher(TelicentGraphSchema.FIELD_RELATIONSHIP_COUNTS, new RelationshipCountsPlaceholderFetcher())
+                                        .dataFetcher(TelicentGraphSchema.FIELD_RELATIONSHIP_COUNTS, nodePlaceholderFetcher)
+                                        .dataFetcher(TelicentGraphSchema.FIELD_RELATIONSHIP_FACETS, nodePlaceholderFetcher)
                             )
                             .type(TelicentGraphSchema.TYPE_RELATIONSHIP,
                                   // The Telicent Graph schema uses underscores in these property names which defeats
@@ -87,6 +88,21 @@ public class TelicentGraphExecutor extends AbstractDatasetExecutor {
                                               .dataFetcher(TelicentGraphSchema.FIELD_INSTANCES, new InstancesCountFetcher())
                                               .dataFetcher(TelicentGraphSchema.FIELD_TYPES, new NodeTypeCountsFetcher())
                                               .dataFetcher(TelicentGraphSchema.FIELD_PROPERTIES, new LiteralsCountFetcher())
+                            )
+                            // The facets are a bit of a workaround
+                            // We want to lazily compute the facet information BUT it's nested two levels beneath our
+                            // Node type.  Therefore, for the NodeRelFacets type we use a fetcher that simply injects
+                            // a placeholder value that includes the fetchers to use at the lower level.
+                            .type(TelicentGraphSchema.TYPE_RELATIONSHIP_FACETS,
+                                        t -> t.dataFetcher(TelicentGraphSchema.FIELD_INBOUND_RELATIONSHIPS, new FacetPlaceholderFetcher(new RelationshipPredicateFacetsFetcher(EdgeDirection.IN), new RelationshipTypeFacetsFetcher(EdgeDirection.IN)))
+                                              .dataFetcher(TelicentGraphSchema.FIELD_OUTBOUND_RELATIONSHIPS, new FacetPlaceholderFetcher(new RelationshipPredicateFacetsFetcher(EdgeDirection.OUT), new RelationshipTypeFacetsFetcher(EdgeDirection.OUT)))
+                            )
+                            // Then at the RelFacetInfo level we use the general purpose FacetsFetcher, this inspects
+                            // the placeholder to find the Node we're computing facets for and selects the appropriate
+                            // fetcher to actually call based upon the field being fetched
+                            .type(TelicentGraphSchema.TYPE_RELATIONSHIP_FACET_INFO,
+                                        t -> t.dataFetcher(TelicentGraphSchema.FIELD_TYPES, new FacetsFetcher())
+                                                     .dataFetcher(TelicentGraphSchema.FIELD_PREDICATES, new FacetsFetcher())
                             )
                             .type(TelicentGraphSchema.TYPE_STATE,
                                   t -> t.dataFetcher(TelicentGraphSchema.FIELD_TYPE, new StateTypeFetcher())

--- a/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/fetchers/telicent/graph/AbstractLimitOffsetPagingFetcher.java
+++ b/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/fetchers/telicent/graph/AbstractLimitOffsetPagingFetcher.java
@@ -103,15 +103,33 @@ public abstract class AbstractLimitOffsetPagingFetcher<TSource, TInput, TOutput>
      * @return Stream with paging applied
      */
     protected Stream<TInput> applyLimitAndOffset(DataFetchingEnvironment environment, Stream<TInput> stream) {
+        return applyLimitAndOffset(environment, stream, this.defaultLimit, this.maxLimit);
+    }
+
+    /**
+     * Applies limit and offset, if any, to the given stream
+     *
+     * @param environment  Data Fetching environment
+     * @param stream       Stream to apply paging to
+     * @param defaultLimit Default limit to apply if not provided in arguments
+     * @param maxLimit     Maximum limit to apply
+     * @param <T>          Element type
+     * @return Stream with paging applied
+     */
+    public static <T> Stream<T> applyLimitAndOffset(DataFetchingEnvironment environment, Stream<T> stream,
+                                                    long defaultLimit, long maxLimit) {
         Integer limit = environment.getArgument(TelicentGraphSchema.ARGUMENT_LIMIT);
         Integer offset = environment.getArgument(TelicentGraphSchema.ARGUMENT_OFFSET);
         if (offset != null && offset > 1) {
             stream = stream.skip(offset.longValue() - 1);
         }
         if (limit != null && limit > 0) {
-            stream = stream.limit(Math.min(limit.longValue(), this.maxLimit));
+            if (limit > maxLimit) {
+                throw new IllegalArgumentException("Requested limit " + limit + " exceeds the maximum limit " + maxLimit);
+            }
+            stream = stream.limit(limit.longValue());
         } else {
-            stream = stream.limit(this.defaultLimit);
+            stream = stream.limit(defaultLimit);
         }
         return stream;
     }

--- a/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/fetchers/telicent/graph/FacetPlaceholderFetcher.java
+++ b/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/fetchers/telicent/graph/FacetPlaceholderFetcher.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (C) Telicent Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.telicent.jena.graphql.fetchers.telicent.graph;
+
+import graphql.schema.DataFetcher;
+import graphql.schema.DataFetchingEnvironment;
+import io.telicent.jena.graphql.schemas.telicent.graph.models.FacetInfo;
+import io.telicent.jena.graphql.schemas.telicent.graph.models.FacetInfoPlaceholder;
+import io.telicent.jena.graphql.schemas.telicent.graph.models.NodePlaceholder;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * A data fetcher that simply injects a placeholder object that will be consumed by other data fetchers
+ * <p>
+ * See {@link NodePlaceholderFetcher} for discussion of why fetchers like this are needed.
+ * </p>
+ */
+public class FacetPlaceholderFetcher implements DataFetcher<FacetInfoPlaceholder> {
+    private final DataFetcher<List<FacetInfo>> predicatesFetcher, typesFetcher;
+
+    /**
+     * Creates a new placeholder fetcher
+     *
+     * @param predicatesFetcher Predicates fetcher
+     * @param typesFetcher      Types fetcher
+     */
+    public FacetPlaceholderFetcher(DataFetcher<List<FacetInfo>> predicatesFetcher,
+                                   DataFetcher<List<FacetInfo>> typesFetcher) {
+        this.predicatesFetcher = Objects.requireNonNull(predicatesFetcher);
+        this.typesFetcher = Objects.requireNonNull(typesFetcher);
+    }
+
+    @Override
+    public FacetInfoPlaceholder get(DataFetchingEnvironment environment) throws Exception {
+        NodePlaceholder node = environment.getSource();
+        return new FacetInfoPlaceholder(node.parent(), this.predicatesFetcher, this.typesFetcher);
+    }
+}

--- a/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/fetchers/telicent/graph/FacetsFetcher.java
+++ b/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/fetchers/telicent/graph/FacetsFetcher.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (C) Telicent Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.telicent.jena.graphql.fetchers.telicent.graph;
+
+import graphql.schema.DataFetcher;
+import graphql.schema.DataFetchingEnvironment;
+import io.telicent.jena.graphql.schemas.telicent.graph.TelicentGraphSchema;
+import io.telicent.jena.graphql.schemas.telicent.graph.models.FacetInfo;
+import io.telicent.jena.graphql.schemas.telicent.graph.models.FacetInfoPlaceholder;
+
+import java.util.List;
+
+/**
+ * A facet fetcher that delegates to another fetcher
+ */
+public class FacetsFetcher implements DataFetcher<List<FacetInfo>> {
+
+    @Override
+    public List<FacetInfo> get(DataFetchingEnvironment environment) throws Exception {
+        FacetInfoPlaceholder placeholder = environment.getSource();
+        return switch (environment.getField().getName()) {
+            case TelicentGraphSchema.FIELD_TYPES -> placeholder.typesFetcher().get(environment);
+            case TelicentGraphSchema.FIELD_PREDICATES -> placeholder.predicatesFetcher().get(environment);
+            default -> throw new IllegalArgumentException("Unsupported field: " + environment.getField().getName());
+        };
+    }
+}

--- a/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/fetchers/telicent/graph/InstancesCountFetcher.java
+++ b/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/fetchers/telicent/graph/InstancesCountFetcher.java
@@ -13,7 +13,7 @@
 package io.telicent.jena.graphql.fetchers.telicent.graph;
 
 import graphql.schema.DataFetchingEnvironment;
-import io.telicent.jena.graphql.schemas.telicent.graph.models.RelationshipCounts;
+import io.telicent.jena.graphql.schemas.telicent.graph.models.NodePlaceholder;
 import io.telicent.jena.graphql.schemas.telicent.graph.models.TelicentGraphNode;
 import org.apache.jena.graph.Node;
 import org.apache.jena.sparql.core.DatasetGraph;
@@ -26,7 +26,7 @@ import java.util.stream.Stream;
 public class InstancesCountFetcher extends AbstractInstancesFetcher<Integer> {
     @Override
     protected TelicentGraphNode getSource(DataFetchingEnvironment environment) {
-        RelationshipCounts counts = environment.getSource();
+        NodePlaceholder counts = environment.getSource();
         return counts.parent();
     }
 

--- a/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/fetchers/telicent/graph/LiteralsCountFetcher.java
+++ b/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/fetchers/telicent/graph/LiteralsCountFetcher.java
@@ -13,7 +13,7 @@
 package io.telicent.jena.graphql.fetchers.telicent.graph;
 
 import graphql.schema.DataFetchingEnvironment;
-import io.telicent.jena.graphql.schemas.telicent.graph.models.RelationshipCounts;
+import io.telicent.jena.graphql.schemas.telicent.graph.models.NodePlaceholder;
 import io.telicent.jena.graphql.schemas.telicent.graph.models.TelicentGraphNode;
 import org.apache.jena.sparql.core.DatasetGraph;
 import org.apache.jena.sparql.core.Quad;
@@ -26,7 +26,7 @@ import java.util.stream.Stream;
 public class LiteralsCountFetcher extends AbstractLiteralsFetcher<Integer> {
     @Override
     protected TelicentGraphNode getSource(DataFetchingEnvironment environment) {
-        RelationshipCounts counts = environment.getSource();
+        NodePlaceholder counts = environment.getSource();
         return counts.parent();
     }
 

--- a/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/fetchers/telicent/graph/NodePlaceholderFetcher.java
+++ b/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/fetchers/telicent/graph/NodePlaceholderFetcher.java
@@ -14,21 +14,21 @@ package io.telicent.jena.graphql.fetchers.telicent.graph;
 
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
-import io.telicent.jena.graphql.schemas.telicent.graph.models.RelationshipCounts;
+import io.telicent.jena.graphql.schemas.telicent.graph.models.NodePlaceholder;
 import io.telicent.jena.graphql.schemas.telicent.graph.models.TelicentGraphNode;
 
 /**
  * A placeholder fetcher that returns a simple record class with a reference back to the parent node
  * <p>
  * This is needed because GraphQL Java doesn't allow a non-scalar typed field to have an empty value (unless explicitly
- * nullable), and we need to have a placeholder object present so that the fetchers that actually compute the counts
- * can get access to the parent {@link TelicentGraphNode} they need to find the things to count.
+ * nullable), and we need to have a placeholder object present so that the fetchers that actually compute further
+ * information can get access to the parent {@link TelicentGraphNode} they need to find the things to fetch.
  * </p>
  */
-public class RelationshipCountsPlaceholderFetcher implements DataFetcher<RelationshipCounts> {
+public class NodePlaceholderFetcher implements DataFetcher<NodePlaceholder> {
     @Override
-    public RelationshipCounts get(DataFetchingEnvironment environment) throws Exception {
+    public NodePlaceholder get(DataFetchingEnvironment environment) throws Exception {
         TelicentGraphNode source = environment.getSource();
-        return new RelationshipCounts(source);
+        return new NodePlaceholder(source);
     }
 }

--- a/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/fetchers/telicent/graph/NodeTypeCountsFetcher.java
+++ b/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/fetchers/telicent/graph/NodeTypeCountsFetcher.java
@@ -13,7 +13,7 @@
 package io.telicent.jena.graphql.fetchers.telicent.graph;
 
 import graphql.schema.DataFetchingEnvironment;
-import io.telicent.jena.graphql.schemas.telicent.graph.models.RelationshipCounts;
+import io.telicent.jena.graphql.schemas.telicent.graph.models.NodePlaceholder;
 import io.telicent.jena.graphql.schemas.telicent.graph.models.TelicentGraphNode;
 import org.apache.jena.graph.Node;
 import org.apache.jena.sparql.core.DatasetGraph;
@@ -26,7 +26,7 @@ import java.util.stream.Stream;
 public class NodeTypeCountsFetcher extends AbstractNodeTypesFetcher<Integer> {
     @Override
     protected TelicentGraphNode getSource(DataFetchingEnvironment environment) {
-        RelationshipCounts counts = environment.getSource();
+        NodePlaceholder counts = environment.getSource();
         return counts.parent();
     }
 

--- a/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/fetchers/telicent/graph/RelationshipPredicateFacetsFetcher.java
+++ b/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/fetchers/telicent/graph/RelationshipPredicateFacetsFetcher.java
@@ -15,41 +15,50 @@ package io.telicent.jena.graphql.fetchers.telicent.graph;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
 import io.telicent.jena.graphql.schemas.models.EdgeDirection;
+import io.telicent.jena.graphql.schemas.telicent.graph.models.FacetInfo;
+import io.telicent.jena.graphql.schemas.telicent.graph.models.FacetInfoPlaceholder;
 import io.telicent.jena.graphql.schemas.telicent.graph.models.NodePlaceholder;
 import io.telicent.jena.graphql.schemas.telicent.graph.models.TelicentGraphNode;
 import org.apache.jena.sparql.core.DatasetGraph;
 import org.apache.jena.sparql.core.Quad;
 
+import java.util.List;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
- * A GraphQL {@link DataFetcher} that finds the counts of incoming/outgoing relationships for a node
+ * A GraphQL {@link DataFetcher} that finds the predicate facets of incoming/outgoing relationships for a node
  */
-public class RelationshipCountsFetcher extends AbstractRelationshipsFetcher<Integer> {
+public class RelationshipPredicateFacetsFetcher extends AbstractRelationshipsFetcher<List<FacetInfo>> {
 
     /**
      * Creates a new relationship counts fetcher
+     *
      * @param direction Direction of relationships to count
      */
-    public RelationshipCountsFetcher(EdgeDirection direction) {
+    public RelationshipPredicateFacetsFetcher(EdgeDirection direction) {
         super(direction);
     }
 
     @Override
     protected TelicentGraphNode getSource(DataFetchingEnvironment environment) {
-        NodePlaceholder counts = environment.getSource();
-        return counts.parent();
+        FacetInfoPlaceholder placeholder = environment.getSource();
+        return placeholder.node();
     }
 
     @Override
-    protected Integer map(DataFetchingEnvironment environment, DatasetGraph dsg, TelicentGraphNode node,
-                          Stream<Quad> input) {
-        return Math.toIntExact(input.count());
+    protected List<FacetInfo> map(DataFetchingEnvironment environment, DatasetGraph dsg, TelicentGraphNode node,
+                                  Stream<Quad> input) {
+        return input.collect(Collectors.groupingBy(Quad::getPredicate, Collectors.counting()))
+                    .entrySet()
+                    .stream()
+                    .map(e -> new FacetInfo(e.getKey(), dsg.prefixes(), e.getValue().intValue()))
+                    .toList();
     }
 
     @Override
     protected Stream<Quad> applyLimitAndOffset(DataFetchingEnvironment environment, Stream<Quad> stream) {
-        // Want the full count so don't apply paging
+        // Want the full facets information so don't apply paging
         return stream;
     }
 }

--- a/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/fetchers/telicent/graph/RelationshipTypeFacetsFetcher.java
+++ b/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/fetchers/telicent/graph/RelationshipTypeFacetsFetcher.java
@@ -15,41 +15,54 @@ package io.telicent.jena.graphql.fetchers.telicent.graph;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
 import io.telicent.jena.graphql.schemas.models.EdgeDirection;
+import io.telicent.jena.graphql.schemas.telicent.graph.models.FacetInfo;
+import io.telicent.jena.graphql.schemas.telicent.graph.models.FacetInfoPlaceholder;
 import io.telicent.jena.graphql.schemas.telicent.graph.models.NodePlaceholder;
 import io.telicent.jena.graphql.schemas.telicent.graph.models.TelicentGraphNode;
+import org.apache.jena.graph.Node;
 import org.apache.jena.sparql.core.DatasetGraph;
 import org.apache.jena.sparql.core.Quad;
+import org.apache.jena.vocabulary.RDF;
 
+import java.util.List;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
- * A GraphQL {@link DataFetcher} that finds the counts of incoming/outgoing relationships for a node
+ * A GraphQL {@link DataFetcher} that finds the type facets of incoming/outgoing relationships for a node
  */
-public class RelationshipCountsFetcher extends AbstractRelationshipsFetcher<Integer> {
+public class RelationshipTypeFacetsFetcher extends AbstractRelationshipsFetcher<List<FacetInfo>> {
 
     /**
      * Creates a new relationship counts fetcher
+     *
      * @param direction Direction of relationships to count
      */
-    public RelationshipCountsFetcher(EdgeDirection direction) {
+    public RelationshipTypeFacetsFetcher(EdgeDirection direction) {
         super(direction);
     }
 
     @Override
     protected TelicentGraphNode getSource(DataFetchingEnvironment environment) {
-        NodePlaceholder counts = environment.getSource();
-        return counts.parent();
+        FacetInfoPlaceholder placeholder = environment.getSource();
+        return placeholder.node();
     }
 
     @Override
-    protected Integer map(DataFetchingEnvironment environment, DatasetGraph dsg, TelicentGraphNode node,
-                          Stream<Quad> input) {
-        return Math.toIntExact(input.count());
+    protected List<FacetInfo> map(DataFetchingEnvironment environment, DatasetGraph dsg, TelicentGraphNode node,
+                                  Stream<Quad> input) {
+        return input.flatMap(q -> dsg.stream(Node.ANY, this.direction == EdgeDirection.IN ? q.getSubject() : q.getObject(), RDF.type.asNode(),
+                                             Node.ANY))
+                    .collect(Collectors.groupingBy(Quad::getObject, Collectors.counting()))
+                    .entrySet()
+                    .stream()
+                    .map(e -> new FacetInfo(e.getKey(), dsg.prefixes(), e.getValue().intValue()))
+                    .toList();
     }
 
     @Override
     protected Stream<Quad> applyLimitAndOffset(DataFetchingEnvironment environment, Stream<Quad> stream) {
-        // Want the full count so don't apply paging
+        // Want the full facets information so don't apply paging
         return stream;
     }
 }

--- a/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/fetchers/telicent/graph/StartingNodesFetcher.java
+++ b/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/fetchers/telicent/graph/StartingNodesFetcher.java
@@ -24,8 +24,11 @@ import org.apache.jena.sparql.core.DatasetGraph;
 import org.apache.jena.system.Txn;
 
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * A GraphQL {@link DataFetcher} that finds the starting nodes for a query
@@ -49,23 +52,30 @@ public class StartingNodesFetcher implements DataFetcher<Object> {
         DatasetGraph dsg = context.getDatasetGraph();
         String rawGraph = environment.getArgument(TelicentGraphSchema.ARGUMENT_GRAPH);
         Node graphFilter = StringUtils.isNotBlank(rawGraph) ? parseStart(rawGraph) : Node.ANY;
-        List<Node> startFilters = parseStarts(multiSelect ? environment.getArgument(TelicentGraphSchema.ARGUMENT_URIS) :
-                                              environment.getArgument(TelicentGraphSchema.ARGUMENT_URI));
+        Set<Node> startFilters = parseStarts(multiSelect ? environment.getArgument(TelicentGraphSchema.ARGUMENT_URIS) :
+                                             environment.getArgument(TelicentGraphSchema.ARGUMENT_URI));
+
 
         return Txn.calculateRead(dsg, () -> {
-            List<TelicentGraphNode> nodes = startFilters.stream()
-                                                        .distinct()
-                                                        .filter(n -> usedAsSubjectOrObject(n, dsg, graphFilter))
-                                                        .map(n -> new TelicentGraphNode(n, dsg.prefixes()))
-                                                        .collect(Collectors.toList());
+            List<TelicentGraphNode> nodes = select(environment, startFilters, dsg, graphFilter).map(
+                    n -> new TelicentGraphNode(n, dsg.prefixes())).collect(Collectors.toList());
             return multiSelect ? nodes : (!nodes.isEmpty() ? nodes.get(0) : null);
         });
     }
 
+    private static Stream<Node> select(DataFetchingEnvironment environment, Set<Node> startFilters, DatasetGraph dsg,
+                                       Node graphFilter) {
+        Stream<Node> selection = startFilters.stream().filter(n -> usedAsSubjectOrObject(n, dsg, graphFilter));
+        return AbstractLimitOffsetPagingFetcher.applyLimitAndOffset(environment, selection,
+                                                                    TelicentGraphSchema.DEFAULT_LIMIT,
+                                                                    TelicentGraphSchema.MAX_LIMIT);
+    }
+
     /**
      * Given a node checks whether it is used as either the subject/object of any quads in the dataset
-     * @param n Node
-     * @param dsg Dataset
+     *
+     * @param n           Node
+     * @param dsg         Dataset
      * @param graphFilter Graph node
      * @return True if used as a subject/object, false otherwise
      */
@@ -74,7 +84,7 @@ public class StartingNodesFetcher implements DataFetcher<Object> {
     }
 
     @SuppressWarnings("unchecked")
-    private List<Node> parseStarts(Object rawStart) {
+    private Set<Node> parseStarts(Object rawStart) {
         if (rawStart == null) {
             throw new IllegalArgumentException(
                     "Required argument" + (this.multiSelect ? TelicentGraphSchema.ARGUMENT_URIS :
@@ -82,7 +92,7 @@ public class StartingNodesFetcher implements DataFetcher<Object> {
         }
         if (this.multiSelect) {
             if (rawStart instanceof List<?>) {
-                List<Node> starts = new ArrayList<>();
+                Set<Node> starts = new LinkedHashSet<>();
                 for (String uri : (List<String>) rawStart) {
                     starts.add(parseStart(uri));
                 }
@@ -94,7 +104,7 @@ public class StartingNodesFetcher implements DataFetcher<Object> {
             }
         } else {
             if (rawStart instanceof String) {
-                return List.of(parseStart((String) rawStart));
+                return Set.of(parseStart((String) rawStart));
             } else {
                 throw new IllegalArgumentException(
                         "Argument " + TelicentGraphSchema.ARGUMENT_URI + " received as wrong type, expected String but got " + rawStart.getClass()

--- a/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/fetchers/telicent/graph/StartingStatesFetcher.java
+++ b/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/fetchers/telicent/graph/StartingStatesFetcher.java
@@ -25,6 +25,7 @@ import org.apache.jena.vocabulary.RDF;
 
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * A GraphQL {@link DataFetcher} that finds the starting states for a states query
@@ -44,10 +45,14 @@ public class StartingStatesFetcher implements DataFetcher<List<State>> {
         DatasetGraph dsg = context.getDatasetGraph();
         Node node = StartingNodesFetcher.parseStart(environment.getArgument(TelicentGraphSchema.ARGUMENT_URI));
 
-        return Txn.calculateRead(dsg, () -> findStates(dsg, node));
+        return Txn.calculateRead(dsg, () -> AbstractLimitOffsetPagingFetcher.applyLimitAndOffset(environment,
+                                                                                                 findStates(dsg, node),
+                                                                                                 TelicentGraphSchema.DEFAULT_LIMIT,
+                                                                                                 TelicentGraphSchema.MAX_LIMIT)
+                                                                            .collect(Collectors.toList()));
     }
 
-    private static List<State> findStates(DatasetGraph dsg, Node node) {
+    private static Stream<State> findStates(DatasetGraph dsg, Node node) {
         return IesFetchers.STATE_PREDICATES.stream()
                                            .flatMap(p -> dsg.stream(Node.ANY, Node.ANY, p,
                                                                     node)
@@ -61,7 +66,6 @@ public class StartingStatesFetcher implements DataFetcher<List<State>> {
                                                             .map(Quad::getSubject)
                                                             .distinct()
                                                             .map(n -> new State(n, p,
-                                                                                node)))
-                                           .collect(Collectors.toList());
+                                                                                node)));
     }
 }

--- a/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/schemas/telicent/graph/TelicentGraphSchema.java
+++ b/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/schemas/telicent/graph/TelicentGraphSchema.java
@@ -63,6 +63,14 @@ public class TelicentGraphSchema {
      */
     public static final String TYPE_RELATIONSHIP_COUNTS = "NodeRelCounts";
     /**
+     * Node relationship facets type
+     */
+    public static final String TYPE_RELATIONSHIP_FACETS = "NodeRelFacets";
+    /**
+     * Relationship facet information type
+     */
+    public static final String TYPE_RELATIONSHIP_FACET_INFO = "RelFacetInfo";
+    /**
      * Property type
      */
     public static final String TYPE_PROPERTY = "Property";
@@ -147,6 +155,10 @@ public class TelicentGraphSchema {
      */
     public static final String FIELD_TYPES = "types";
     /**
+     * Predicates field
+     */
+    public static final String FIELD_PREDICATES = "predicates";
+    /**
      * Properties field
      */
     public static final String FIELD_PROPERTIES = "properties";
@@ -162,6 +174,10 @@ public class TelicentGraphSchema {
      * Relationship counts field
      */
     public static final String FIELD_RELATIONSHIP_COUNTS = "relCounts";
+    /**
+     * Relationship facets field
+     */
+    public static final String FIELD_RELATIONSHIP_FACETS = "relFacets";
     /**
      * URI field
      */

--- a/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/schemas/telicent/graph/models/FacetInfo.java
+++ b/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/schemas/telicent/graph/models/FacetInfo.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (C) Telicent Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.telicent.jena.graphql.schemas.telicent.graph.models;
+
+import org.apache.jena.graph.Node;
+import org.apache.jena.riot.system.PrefixMap;
+
+/**
+ * Represents facet information
+ */
+public class FacetInfo extends TelicentGraphNode {
+
+    private final int count;
+
+    /**
+     * Creates new facet information
+     *
+     * @param node     Node that identifies the facet
+     * @param prefixes Prefixes map, used to provide the shortened URI if possible
+     * @param count    Count for the facet
+     */
+    public FacetInfo(Node node, PrefixMap prefixes, int count) {
+        super(node, prefixes);
+        this.count = count;
+    }
+
+    /**
+     * Gets the count for this facet
+     *
+     * @return Count
+     */
+    public int getCount() {
+        return this.count;
+    }
+
+}

--- a/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/schemas/telicent/graph/models/FacetInfoPlaceholder.java
+++ b/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/schemas/telicent/graph/models/FacetInfoPlaceholder.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright (C) Telicent Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.telicent.jena.graphql.schemas.telicent.graph.models;
+
+import graphql.schema.DataFetcher;
+
+import java.util.List;
+
+/**
+ * A placeholder for use in fetching Facet information
+ *
+ * @param node              Node for which we are computing facets
+ * @param predicatesFetcher Fetcher used to compute predicates facet
+ * @param typesFetcher      Fetcher used to compute types facet
+ */
+public record FacetInfoPlaceholder(TelicentGraphNode node, DataFetcher<List<FacetInfo>> predicatesFetcher,
+                                   DataFetcher<List<FacetInfo>> typesFetcher) {
+}

--- a/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/schemas/telicent/graph/models/NodePlaceholder.java
+++ b/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/schemas/telicent/graph/models/NodePlaceholder.java
@@ -13,9 +13,9 @@
 package io.telicent.jena.graphql.schemas.telicent.graph.models;
 
 /**
- * Placeholder for relationship counts
+ * Placeholder for holding a node
  *
  * @param parent Parent node
  */
-public record RelationshipCounts(TelicentGraphNode parent) {
+public record NodePlaceholder(TelicentGraphNode parent) {
 }

--- a/telicent-graph-schema/src/main/resources/io/telicent/jena/graphql/schemas/telicent/graph/ies.graphqls
+++ b/telicent-graph-schema/src/main/resources/io/telicent/jena/graphql/schemas/telicent/graph/ies.graphqls
@@ -8,6 +8,7 @@ type Node {
     outRels(limit: Int = 50, offset: Int = 1): [Rel]! # An array of Rels where the current Node is in the domain position
     inRels(limit: Int = 50, offset: Int = 1): [Rel]! # An array of Rels where the current Node is in the range position
     relCounts: NodeRelCounts! # Relationship counts information
+    relFacets: NodeRelFacets!
     instances(limit: Int = 50, offset: Int = 1): [Node] # If the node is a class, this will return an array of its instances
 }
 
@@ -26,6 +27,22 @@ type NodeRelCounts { # Counts of relationships available for a Node
     properties: Int
     types: Int
     instances: Int
+}
+
+type NodeRelFacets {
+    inRels: RelFacetInfo!
+    outRels: RelFacetInfo!
+}
+
+type RelFacetInfo {
+    types: [FacetInfo!]!
+    predicates: [FacetInfo!]!
+}
+
+type FacetInfo {
+    uri: String! # Full URI
+    shortUri: String! # If a shortened (namespace prefixed) form of the uri is available, otherwise returns full uri
+    count: Int
 }
 
 type Property { #A literal property

--- a/telicent-graph-schema/src/main/resources/io/telicent/jena/graphql/schemas/telicent/graph/ies.graphqls
+++ b/telicent-graph-schema/src/main/resources/io/telicent/jena/graphql/schemas/telicent/graph/ies.graphqls
@@ -89,7 +89,7 @@ type Query {
         typeFilter: String
     ): SearchResults
     getAllEntities(graph: String): [Node]
-    states(uri: String!): [State]!
+    states(uri: String!, limit: Int = 50, offset: Int = 1): [State]!
     node(graph: String, uri: String!): Node
-    nodes(graph: String, uris: [String!]!): [Node]
+    nodes(graph: String, uris: [String!]!, limit: Int = 50, offset: Int = 1): [Node]
 }

--- a/telicent-graph-schema/src/test/java/io/telicent/jena/graphql/fetchers/telicent/graph/TestInstancesFetcher.java
+++ b/telicent-graph-schema/src/test/java/io/telicent/jena/graphql/fetchers/telicent/graph/TestInstancesFetcher.java
@@ -15,7 +15,7 @@ package io.telicent.jena.graphql.fetchers.telicent.graph;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
 import io.telicent.jena.graphql.schemas.telicent.graph.TelicentGraphSchema;
-import io.telicent.jena.graphql.schemas.telicent.graph.models.RelationshipCounts;
+import io.telicent.jena.graphql.schemas.telicent.graph.models.NodePlaceholder;
 import io.telicent.jena.graphql.schemas.telicent.graph.models.TelicentGraphNode;
 import org.apache.jena.graph.Node;
 import org.apache.jena.sparql.core.DatasetGraph;
@@ -120,7 +120,7 @@ public class TestInstancesFetcher extends AbstractFetcherTests {
         Node type = createURI("SomeType");
         generateManyInstances(dsg, graph, type);
         DataFetchingEnvironment environment =
-                prepareFetchingEnvironment(dsg, new RelationshipCounts(new TelicentGraphNode(type, null)));
+                prepareFetchingEnvironment(dsg, new NodePlaceholder(new TelicentGraphNode(type, null)));
 
         // When
         Integer count = fetcher.get(environment);

--- a/telicent-graph-schema/src/test/java/io/telicent/jena/graphql/fetchers/telicent/graph/TestLiteralsFetcher.java
+++ b/telicent-graph-schema/src/test/java/io/telicent/jena/graphql/fetchers/telicent/graph/TestLiteralsFetcher.java
@@ -16,7 +16,7 @@ import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
 import io.telicent.jena.graphql.schemas.telicent.graph.TelicentGraphSchema;
 import io.telicent.jena.graphql.schemas.telicent.graph.models.LiteralProperty;
-import io.telicent.jena.graphql.schemas.telicent.graph.models.RelationshipCounts;
+import io.telicent.jena.graphql.schemas.telicent.graph.models.NodePlaceholder;
 import io.telicent.jena.graphql.schemas.telicent.graph.models.TelicentGraphNode;
 import org.apache.jena.datatypes.xsd.XSDDatatype;
 import org.apache.jena.graph.Node;
@@ -58,7 +58,7 @@ public class TestLiteralsFetcher extends AbstractFetcherTests {
         Node subject = createURI("subject");
         generateManyLiterals(dsg, graph, subject);
         DataFetchingEnvironment environment =
-                prepareFetchingEnvironment(dsg, new RelationshipCounts(new TelicentGraphNode(subject, null)));
+                prepareFetchingEnvironment(dsg, new NodePlaceholder(new TelicentGraphNode(subject, null)));
 
         // When
         Integer count = fetcher.get(environment);

--- a/telicent-graph-schema/src/test/java/io/telicent/jena/graphql/fetchers/telicent/graph/TestNodeTypesFetcher.java
+++ b/telicent-graph-schema/src/test/java/io/telicent/jena/graphql/fetchers/telicent/graph/TestNodeTypesFetcher.java
@@ -15,7 +15,7 @@ package io.telicent.jena.graphql.fetchers.telicent.graph;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
 import io.telicent.jena.graphql.schemas.telicent.graph.TelicentGraphSchema;
-import io.telicent.jena.graphql.schemas.telicent.graph.models.RelationshipCounts;
+import io.telicent.jena.graphql.schemas.telicent.graph.models.NodePlaceholder;
 import io.telicent.jena.graphql.schemas.telicent.graph.models.TelicentGraphNode;
 import org.apache.jena.graph.Node;
 import org.apache.jena.sparql.core.DatasetGraph;
@@ -121,7 +121,7 @@ public class TestNodeTypesFetcher extends AbstractFetcherTests {
         Node subject = createURI("subject");
         generateManyTypes(dsg, graph, subject);
         DataFetchingEnvironment environment =
-                prepareFetchingEnvironment(dsg, new RelationshipCounts(new TelicentGraphNode(subject, null)));
+                prepareFetchingEnvironment(dsg, new NodePlaceholder(new TelicentGraphNode(subject, null)));
 
         // When
         Integer count = fetcher.get(environment);

--- a/telicent-graph-schema/src/test/java/io/telicent/jena/graphql/fetchers/telicent/graph/TestRelationshipsFetcher.java
+++ b/telicent-graph-schema/src/test/java/io/telicent/jena/graphql/fetchers/telicent/graph/TestRelationshipsFetcher.java
@@ -17,7 +17,7 @@ import graphql.schema.DataFetchingEnvironment;
 import io.telicent.jena.graphql.schemas.models.EdgeDirection;
 import io.telicent.jena.graphql.schemas.telicent.graph.TelicentGraphSchema;
 import io.telicent.jena.graphql.schemas.telicent.graph.models.Relationship;
-import io.telicent.jena.graphql.schemas.telicent.graph.models.RelationshipCounts;
+import io.telicent.jena.graphql.schemas.telicent.graph.models.NodePlaceholder;
 import io.telicent.jena.graphql.schemas.telicent.graph.models.TelicentGraphNode;
 import org.apache.jena.graph.Node;
 import org.apache.jena.sparql.core.DatasetGraph;
@@ -99,7 +99,7 @@ public class TestRelationshipsFetcher extends AbstractFetcherTests {
         Node subject = createURI("subject");
         generateManyRelationships(dsg, graph, subject);
         DataFetchingEnvironment environment =
-                prepareFetchingEnvironment(dsg, new RelationshipCounts(new TelicentGraphNode(subject, null)));
+                prepareFetchingEnvironment(dsg, new NodePlaceholder(new TelicentGraphNode(subject, null)));
 
         // When
         Integer inCount = inFetcher.get(environment);

--- a/telicent-graph-schema/src/test/resources/queries/telicent/graph/single-node-with-paging.graphql
+++ b/telicent-graph-schema/src/test/resources/queries/telicent/graph/single-node-with-paging.graphql
@@ -31,6 +31,28 @@ query($limit: Int, $offset: Int) {
             instances
             properties
         }
+        relFacets {
+            inRels {
+                predicates {
+                    uri
+                    count
+                }
+                types {
+                    uri
+                    count
+                }
+            }
+            outRels {
+                predicates {
+                    uri
+                    count
+                }
+                types {
+                    uri
+                    count
+                }
+            }
+        }
         instances(limit: $limit, offset: $offset) {
             id
             uri


### PR DESCRIPTION
This PR adds a new `relFacets` field to the `Node` type allowing richer facet information to be returned that the caller can use.  Ultimately this will be paired with the ability to filter requests using these facets.

For now we can compute the `predicates` and `types` facets for a `Node`.  For `predicates` we find the unique predicates using in the in/out relationships and summarise how many of such relationships exist per predicate.  For `types` we find the type of the node at the other end of the relationship and summarise how many of such types exist.

Also extends pagination to the `nodes` and `states` queries so callers can page at the query level, as well as at the field level.  In relation to that if a `limit` is requested above the maximum permitted limit that is now treated as an error and query execution aborted.

# Outstanding Work

- [ ] Unit testing
- [ ] Documentation updates