### PR TITLE
Support node filters for relationships (CORE-801)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # GraphQL Extensions for Apache Jena
 
+# 0.10.2
+
+- Telicent Graph Schema improvements:
+    - Added `domainFilter` argument to `inRels` fields to filter inbound relationships to only those which relate to
+      specific subjects
+    - Added `rangeFilter` argument to `outRels` fields to filter outbound relationships to only those which relate to
+      specific objects
+    - Improved performance of `INCLUDE` filters for `predicateFilter`, `domainFilter` and `rangeFilter` by translating
+      these into direct `dsg.stream()` calls for pre-filtering instead of post-filtering a more general `dsg.stream()`
+      call.
+
 # 0.10.1
 
 - Telicent Graph Schema improvements:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,10 @@
 # 0.10.2
 
 - Telicent Graph Schema improvements:
-    - Added `domainFilter` argument to `inRels` fields to filter inbound relationships to only those which relate to
-      specific subjects
-    - Added `rangeFilter` argument to `outRels` fields to filter outbound relationships to only those which relate to
-      specific objects
-    - Improved performance of `INCLUDE` filters for `predicateFilter`, `domainFilter` and `rangeFilter` by translating
-      these into direct `dsg.stream()` calls for pre-filtering instead of post-filtering a more general `dsg.stream()`
-      call.
+    - Added `nodeFilter` argument to `inRels` and `outRels` fields to filter relationships to only those which relate
+      to specific nodes in the graph
+    - Improved performance of `INCLUDE` filters for `predicateFilter`, and `nodeFilter` by translating these into
+      direct `dsg.stream()` calls for pre-filtering instead of post-filtering a more general `dsg.stream()` call.
 
 # 0.10.1
 

--- a/graphql-jena-core/src/main/java/io/telicent/jena/graphql/schemas/models/WrappedNode.java
+++ b/graphql-jena-core/src/main/java/io/telicent/jena/graphql/schemas/models/WrappedNode.java
@@ -103,7 +103,7 @@ public class WrappedNode {
                 WrappedNode s = new WrappedNode((Map<String, Object>) map.get(CoreSchema.SUBJECT_FIELD));
                 WrappedNode p = new WrappedNode((Map<String, Object>) map.get(CoreSchema.PREDICATE_FIELD));
                 WrappedNode o = new WrappedNode((Map<String, Object>) map.get(CoreSchema.OBJECT_FIELD));
-                yield NodeFactory.createTripleNode(s.node, p.node, o.node);
+                yield NodeFactory.createTripleTerm(s.node, p.node, o.node);
             }
         };
     }

--- a/graphql-jena-core/src/test/java/io/telicent/jena/graphql/schemas/models/TestWrappedNode.java
+++ b/graphql-jena-core/src/test/java/io/telicent/jena/graphql/schemas/models/TestWrappedNode.java
@@ -100,7 +100,7 @@ public class TestWrappedNode {
     public void test_WrapperNode_mapNullTriple() {
         // given
         Triple triple = SSE.parseTriple("(:s :p :o)");
-        Node n = NodeFactory.createTripleNode(triple);
+        Node n = createTripleTerm(triple);
         // when
         WrappedNode wrappedNode = new WrappedNode(n);
         // then
@@ -155,7 +155,7 @@ public class TestWrappedNode {
                 { createLiteralString(RANDOM_ID), RANDOM_ID },
                 { createURI(RANDOM_ID), RANDOM_ID },
                 { createVariable(RANDOM_ID), RANDOM_ID },
-                { createTripleNode(Triple.create(createBlankNode(), createBlankNode(), createBlankNode())), null },
+                { createTripleTerm(Triple.create(createBlankNode(), createBlankNode(), createBlankNode())), null },
                 };
     }
 

--- a/graphql-server/src/main/java/io/telicent/jena/graphql/server/GraphQLEntrypoint.java
+++ b/graphql-server/src/main/java/io/telicent/jena/graphql/server/GraphQLEntrypoint.java
@@ -66,7 +66,7 @@ public class GraphQLEntrypoint extends AbstractAppEntrypoint {
         return ServerBuilder.create()
                             .application(GraphQLApplication.class)
                             .displayName("Standalone GraphQL Jena Server")
-                            .localhost()
+                            .allInterfaces()
                             .port(this.port)
                             .withCors(CorsConfigurationBuilder::withDefaults)
                             .withListener(DatasetInitializer.class);

--- a/graphql-server/src/main/java/io/telicent/jena/graphql/server/application/resources/DatasetResource.java
+++ b/graphql-server/src/main/java/io/telicent/jena/graphql/server/application/resources/DatasetResource.java
@@ -21,6 +21,7 @@ import jakarta.servlet.ServletContext;
 import jakarta.validation.constraints.NotNull;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
@@ -45,6 +46,7 @@ public class DatasetResource extends AbstractGraphQLResource {
      * @param operationName  GraphQL Operation name
      * @param variables      GraphQL variables
      * @param extensions     GraphQL extensions
+     * @param headers        HTTP Headers for the request
      * @param servletContext Servlet context
      * @return Response
      */
@@ -55,14 +57,16 @@ public class DatasetResource extends AbstractGraphQLResource {
                           @QueryParam(GraphQLOverHttp.PARAMETER_OPERATION_NAME) String operationName,
                           @QueryParam(GraphQLOverHttp.PARAMETER_VARIABLES) String variables,
                           @QueryParam(GraphQLOverHttp.PARAMETER_EXTENSIONS) String extensions,
-                          @Context ServletContext servletContext) {
-        return executeOrValidateGraphQL(query, operationName, variables, extensions, servletContext, DatasetExecutor.class, false);
+                          @Context HttpHeaders headers, @Context ServletContext servletContext) {
+        return executeOrValidateGraphQL(headers, query, operationName, variables, extensions, servletContext,
+                                        DatasetExecutor.class, false);
     }
 
     /**
      * POST requests using the {@link io.telicent.jena.graphql.schemas.DatasetSchema}
      *
      * @param request        GraphQL Request
+     * @param headers        HTTP Headers for the request
      * @param servletContext Servlet context
      * @return Response
      */
@@ -70,9 +74,10 @@ public class DatasetResource extends AbstractGraphQLResource {
     @POST
     @Consumes({ MediaType.APPLICATION_JSON })
     @Produces({ GraphQLOverHttp.CONTENT_TYPE_GRAPHQL_RESPONSE_JSON, "application/problem+json" })
-    public Response postQuads(GraphQLRequest request, @Context ServletContext servletContext) {
-        return executeOrValidateGraphQL(request.getQuery(), request.getOperationName(), request.getVariables(),
-                              request.getExtensions(), servletContext, DatasetExecutor.class, false);
+    public Response postQuads(GraphQLRequest request, @Context HttpHeaders headers,
+                              @Context ServletContext servletContext) {
+        return executeOrValidateGraphQL(headers, request.getQuery(), request.getOperationName(), request.getVariables(),
+                                        request.getExtensions(), servletContext, DatasetExecutor.class, false);
     }
 
     /**
@@ -82,6 +87,7 @@ public class DatasetResource extends AbstractGraphQLResource {
      * @param operationName  GraphQL Operation name
      * @param variables      GraphQL variables
      * @param extensions     GraphQL extensions
+     * @param headers        HTTP Headers for the request
      * @param servletContext Servlet context
      * @return Response
      */
@@ -92,14 +98,16 @@ public class DatasetResource extends AbstractGraphQLResource {
                              @QueryParam(GraphQLOverHttp.PARAMETER_OPERATION_NAME) String operationName,
                              @QueryParam(GraphQLOverHttp.PARAMETER_VARIABLES) String variables,
                              @QueryParam(GraphQLOverHttp.PARAMETER_EXTENSIONS) String extensions,
-                             @Context ServletContext servletContext) {
-        return executeOrValidateGraphQL(query, operationName, variables, extensions, servletContext, TraversalExecutor.class, false);
+                             @Context HttpHeaders headers, @Context ServletContext servletContext) {
+        return executeOrValidateGraphQL(headers, query, operationName, variables, extensions, servletContext,
+                                        TraversalExecutor.class, false);
     }
 
     /**
      * POST requests using the {@link io.telicent.jena.graphql.schemas.TraversalSchema}
      *
      * @param request        GraphQL Request
+     * @param headers        HTTP Headers for the request
      * @param servletContext Servlet context
      * @return Response
      */
@@ -107,9 +115,10 @@ public class DatasetResource extends AbstractGraphQLResource {
     @POST
     @Consumes({ MediaType.APPLICATION_JSON })
     @Produces({ GraphQLOverHttp.CONTENT_TYPE_GRAPHQL_RESPONSE_JSON, "application/problem+json" })
-    public Response postTraversal(GraphQLRequest request, @Context ServletContext servletContext) {
-        return executeOrValidateGraphQL(request.getQuery(), request.getOperationName(), request.getVariables(),
-                              request.getExtensions(), servletContext, TraversalExecutor.class, false);
+    public Response postTraversal(GraphQLRequest request, @Context HttpHeaders headers,
+                                  @Context ServletContext servletContext) {
+        return executeOrValidateGraphQL(headers, request.getQuery(), request.getOperationName(), request.getVariables(),
+                                        request.getExtensions(), servletContext, TraversalExecutor.class, false);
     }
 
 
@@ -120,6 +129,7 @@ public class DatasetResource extends AbstractGraphQLResource {
      * @param operationName  GraphQL Operation name
      * @param variables      GraphQL variables
      * @param extensions     GraphQL extensions
+     * @param headers        HTTP Headers for the request
      * @param servletContext Servlet context
      * @return Response
      */
@@ -127,17 +137,19 @@ public class DatasetResource extends AbstractGraphQLResource {
     @GET
     @Produces({ GraphQLOverHttp.CONTENT_TYPE_GRAPHQL_RESPONSE_JSON, "application/problem+json" })
     public Response telicent(@QueryParam(GraphQLOverHttp.PARAMETER_QUERY) @NotNull String query,
-                          @QueryParam(GraphQLOverHttp.PARAMETER_OPERATION_NAME) String operationName,
-                          @QueryParam(GraphQLOverHttp.PARAMETER_VARIABLES) String variables,
-                          @QueryParam(GraphQLOverHttp.PARAMETER_EXTENSIONS) String extensions,
-                          @Context ServletContext servletContext) {
-        return executeOrValidateGraphQL(query, operationName, variables, extensions, servletContext, TelicentGraphExecutor.class, false);
+                             @QueryParam(GraphQLOverHttp.PARAMETER_OPERATION_NAME) String operationName,
+                             @QueryParam(GraphQLOverHttp.PARAMETER_VARIABLES) String variables,
+                             @QueryParam(GraphQLOverHttp.PARAMETER_EXTENSIONS) String extensions,
+                             @Context HttpHeaders headers, @Context ServletContext servletContext) {
+        return executeOrValidateGraphQL(headers, query, operationName, variables, extensions, servletContext,
+                                        TelicentGraphExecutor.class, false);
     }
 
     /**
      * POST requests using the {@link io.telicent.jena.graphql.schemas.telicent.graph.TelicentGraphSchema}
      *
      * @param request        GraphQL Request
+     * @param headers        HTTP Headers for the request
      * @param servletContext Servlet context
      * @return Response
      */
@@ -145,9 +157,10 @@ public class DatasetResource extends AbstractGraphQLResource {
     @POST
     @Consumes({ MediaType.APPLICATION_JSON })
     @Produces({ GraphQLOverHttp.CONTENT_TYPE_GRAPHQL_RESPONSE_JSON, "application/problem+json" })
-    public Response postTelicent(GraphQLRequest request, @Context ServletContext servletContext) {
-        return executeOrValidateGraphQL(request.getQuery(), request.getOperationName(), request.getVariables(),
-                              request.getExtensions(), servletContext, TelicentGraphExecutor.class,false);
+    public Response postTelicent(GraphQLRequest request, @Context HttpHeaders headers,
+                                 @Context ServletContext servletContext) {
+        return executeOrValidateGraphQL(headers, request.getQuery(), request.getOperationName(), request.getVariables(),
+                                        request.getExtensions(), servletContext, TelicentGraphExecutor.class, false);
     }
 
     /**
@@ -157,6 +170,7 @@ public class DatasetResource extends AbstractGraphQLResource {
      * @param operationName  GraphQL Operation name
      * @param variables      GraphQL variables
      * @param extensions     GraphQL extensions
+     * @param headers        HTTP Headers for the request
      * @param servletContext Servlet context
      * @return Response
      */
@@ -165,11 +179,12 @@ public class DatasetResource extends AbstractGraphQLResource {
     @GET
     @Produces({ GraphQLOverHttp.CONTENT_TYPE_GRAPHQL_RESPONSE_JSON, "application/problem+json" })
     public Response getValidate(@QueryParam(GraphQLOverHttp.PARAMETER_QUERY) @NotNull String query,
-                             @QueryParam(GraphQLOverHttp.PARAMETER_OPERATION_NAME) String operationName,
-                             @QueryParam(GraphQLOverHttp.PARAMETER_VARIABLES) String variables,
-                             @QueryParam(GraphQLOverHttp.PARAMETER_EXTENSIONS) String extensions,
-                             @Context ServletContext servletContext) {
-        return executeOrValidateGraphQL(query, operationName, variables, extensions, servletContext, DatasetExecutor.class, true);
+                                @QueryParam(GraphQLOverHttp.PARAMETER_OPERATION_NAME) String operationName,
+                                @QueryParam(GraphQLOverHttp.PARAMETER_VARIABLES) String variables,
+                                @QueryParam(GraphQLOverHttp.PARAMETER_EXTENSIONS) String extensions,
+                                @Context HttpHeaders headers, @Context ServletContext servletContext) {
+        return executeOrValidateGraphQL(headers, query, operationName, variables, extensions, servletContext,
+                                        DatasetExecutor.class, true);
     }
 
 
@@ -177,6 +192,7 @@ public class DatasetResource extends AbstractGraphQLResource {
      * POST requests using the {@link io.telicent.jena.graphql.schemas.DatasetSchema}
      *
      * @param request        GraphQL Request
+     * @param headers        HTTP Headers for the request
      * @param servletContext Servlet context
      * @return Response
      */
@@ -184,9 +200,10 @@ public class DatasetResource extends AbstractGraphQLResource {
     @POST
     @Consumes({ MediaType.APPLICATION_JSON })
     @Produces({ GraphQLOverHttp.CONTENT_TYPE_GRAPHQL_RESPONSE_JSON, "application/problem+json" })
-    public Response postValidate(GraphQLRequest request, @Context ServletContext servletContext) {
-        return executeOrValidateGraphQL(request.getQuery(), request.getOperationName(), request.getVariables(),
-                              request.getExtensions(), servletContext, DatasetExecutor.class, true);
+    public Response postValidate(GraphQLRequest request, @Context HttpHeaders headers,
+                                 @Context ServletContext servletContext) {
+        return executeOrValidateGraphQL(headers, request.getQuery(), request.getOperationName(), request.getVariables(),
+                                        request.getExtensions(), servletContext, DatasetExecutor.class, true);
     }
 
 
@@ -197,6 +214,7 @@ public class DatasetResource extends AbstractGraphQLResource {
      * @param operationName  GraphQL Operation name
      * @param variables      GraphQL variables
      * @param extensions     GraphQL extensions
+     * @param headers        HTTP Headers for the request
      * @param servletContext Servlet context
      * @return Response
      */
@@ -204,17 +222,19 @@ public class DatasetResource extends AbstractGraphQLResource {
     @GET
     @Produces({ GraphQLOverHttp.CONTENT_TYPE_GRAPHQL_RESPONSE_JSON, "application/problem+json" })
     public Response validateGetTraversal(@QueryParam(GraphQLOverHttp.PARAMETER_QUERY) @NotNull String query,
-                                      @QueryParam(GraphQLOverHttp.PARAMETER_OPERATION_NAME) String operationName,
-                                      @QueryParam(GraphQLOverHttp.PARAMETER_VARIABLES) String variables,
-                                      @QueryParam(GraphQLOverHttp.PARAMETER_EXTENSIONS) String extensions,
-                                      @Context ServletContext servletContext) {
-        return executeOrValidateGraphQL(query, operationName, variables, extensions, servletContext, TraversalExecutor.class, true);
+                                         @QueryParam(GraphQLOverHttp.PARAMETER_OPERATION_NAME) String operationName,
+                                         @QueryParam(GraphQLOverHttp.PARAMETER_VARIABLES) String variables,
+                                         @QueryParam(GraphQLOverHttp.PARAMETER_EXTENSIONS) String extensions,
+                                         @Context HttpHeaders headers, @Context ServletContext servletContext) {
+        return executeOrValidateGraphQL(headers, query, operationName, variables, extensions, servletContext,
+                                        TraversalExecutor.class, true);
     }
 
     /**
      * POST requests using the {@link io.telicent.jena.graphql.schemas.TraversalSchema}
      *
      * @param request        GraphQL Request
+     * @param headers        HTTP Headers for the request
      * @param servletContext Servlet context
      * @return Response
      */
@@ -222,8 +242,9 @@ public class DatasetResource extends AbstractGraphQLResource {
     @POST
     @Consumes({ MediaType.APPLICATION_JSON })
     @Produces({ GraphQLOverHttp.CONTENT_TYPE_GRAPHQL_RESPONSE_JSON, "application/problem+json" })
-    public Response validatePostTraversal(GraphQLRequest request, @Context ServletContext servletContext) {
-        return executeOrValidateGraphQL(request.getQuery(), request.getOperationName(), request.getVariables(),
+    public Response validatePostTraversal(GraphQLRequest request, @Context HttpHeaders headers,
+                                          @Context ServletContext servletContext) {
+        return executeOrValidateGraphQL(headers, request.getQuery(), request.getOperationName(), request.getVariables(),
                                         request.getExtensions(), servletContext, TraversalExecutor.class, true);
     }
 
@@ -234,6 +255,7 @@ public class DatasetResource extends AbstractGraphQLResource {
      * @param operationName  GraphQL Operation name
      * @param variables      GraphQL variables
      * @param extensions     GraphQL extensions
+     * @param headers        HTTP Headers for the request
      * @param servletContext Servlet context
      * @return Response
      */
@@ -242,17 +264,19 @@ public class DatasetResource extends AbstractGraphQLResource {
     @Consumes({ MediaType.APPLICATION_JSON })
     @Produces({ GraphQLOverHttp.CONTENT_TYPE_GRAPHQL_RESPONSE_JSON, "application/problem+json" })
     public Response getValidateTelicent(@QueryParam(GraphQLOverHttp.PARAMETER_QUERY) String query,
-                             @QueryParam(GraphQLOverHttp.PARAMETER_OPERATION_NAME) String operationName,
-                             @QueryParam(GraphQLOverHttp.PARAMETER_VARIABLES) String variables,
-                             @QueryParam(GraphQLOverHttp.PARAMETER_EXTENSIONS) String extensions,
-                             @Context ServletContext servletContext) {
-        return executeOrValidateGraphQL(query, operationName, variables, extensions, servletContext, TelicentGraphExecutor.class, true);
+                                        @QueryParam(GraphQLOverHttp.PARAMETER_OPERATION_NAME) String operationName,
+                                        @QueryParam(GraphQLOverHttp.PARAMETER_VARIABLES) String variables,
+                                        @QueryParam(GraphQLOverHttp.PARAMETER_EXTENSIONS) String extensions,
+                                        @Context HttpHeaders headers, @Context ServletContext servletContext) {
+        return executeOrValidateGraphQL(headers, query, operationName, variables, extensions, servletContext,
+                                        TelicentGraphExecutor.class, true);
     }
 
     /**
      * POST requests using the {@link io.telicent.jena.graphql.schemas.telicent.graph.TelicentGraphSchema}
      *
      * @param request        GraphQL Request
+     * @param headers        HTTP Headers for the request
      * @param servletContext Servlet context
      * @return Response
      */
@@ -260,9 +284,10 @@ public class DatasetResource extends AbstractGraphQLResource {
     @POST
     @Consumes({ MediaType.APPLICATION_JSON })
     @Produces({ GraphQLOverHttp.CONTENT_TYPE_GRAPHQL_RESPONSE_JSON, "application/problem+json" })
-    public Response postValidateTelicent(GraphQLRequest request, @Context ServletContext servletContext) {
-        return executeOrValidateGraphQL(request.getQuery(), request.getOperationName(), request.getVariables(),
-                                        request.getExtensions(), servletContext, TelicentGraphExecutor.class,true);
+    public Response postValidateTelicent(GraphQLRequest request, @Context HttpHeaders headers,
+                                         @Context ServletContext servletContext) {
+        return executeOrValidateGraphQL(headers, request.getQuery(), request.getOperationName(), request.getVariables(),
+                                        request.getExtensions(), servletContext, TelicentGraphExecutor.class, true);
     }
 
 }

--- a/graphql-server/src/test/java/io/telicent/jena/graphql/server/AbstractResourceTests.java
+++ b/graphql-server/src/test/java/io/telicent/jena/graphql/server/AbstractResourceTests.java
@@ -55,6 +55,7 @@ public class AbstractResourceTests {
         response.close();
     }
 
+    @SuppressWarnings("unchecked")
     protected void verifyFailureWithErrorAndMessage(Response response, Response.Status expectedStatus, String expectedErrorType, String expectedMessage) {
         Assert.assertEquals(response.getStatus(), expectedStatus.getStatusCode());
         List<Map<String,String>> errors = response.readEntity(List.class);

--- a/graphql-server/src/test/java/io/telicent/jena/graphql/server/DatasetResourceValidationTests.java
+++ b/graphql-server/src/test/java/io/telicent/jena/graphql/server/DatasetResourceValidationTests.java
@@ -348,7 +348,7 @@ public class DatasetResourceValidationTests extends AbstractResourceTests {
         when(mockContext.getAttribute(anyString())).thenReturn(null);
         class TestResource extends AbstractGraphQLResource {
             public Response testMethod() {
-                return this.executeOrValidateGraphQL(null, null, Collections.emptyMap(), Collections.emptyMap(), mockContext, String.class, false);
+                return this.executeOrValidateGraphQL(null, null, null, Collections.emptyMap(), Collections.emptyMap(), mockContext, String.class, false);
             }
         }
         TestResource abstractGraphQLResource = new TestResource();

--- a/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/fetchers/telicent/graph/AbstractInstancesFetcher.java
+++ b/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/fetchers/telicent/graph/AbstractInstancesFetcher.java
@@ -14,7 +14,7 @@ package io.telicent.jena.graphql.fetchers.telicent.graph;
 
 import graphql.schema.DataFetchingEnvironment;
 import io.telicent.jena.graphql.schemas.telicent.graph.models.TelicentGraphNode;
-import io.telicent.jena.graphql.schemas.telicent.graph.models.inputs.AbstractFilter;
+import io.telicent.jena.graphql.schemas.telicent.graph.models.inputs.Filter;
 import org.apache.jena.graph.Node;
 import org.apache.jena.sparql.core.DatasetGraph;
 import org.apache.jena.sparql.core.Quad;
@@ -40,7 +40,7 @@ public abstract class AbstractInstancesFetcher<TOutput>
     }
 
     @Override
-    protected Stream<Node> select(DataFetchingEnvironment environment, DatasetGraph dsg, TelicentGraphNode node, List<AbstractFilter> filters) {
+    protected Stream<Node> select(DataFetchingEnvironment environment, DatasetGraph dsg, TelicentGraphNode node, List<Filter> filters) {
         // NB - Filters not enabled for instances (wouldn't make sense anyway!)
         return dsg.stream(Node.ANY, Node.ANY, RDF_TYPE, node.getNode())
                   .filter(q -> q.getSubject().isURI() || q.getSubject().isBlank())

--- a/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/fetchers/telicent/graph/AbstractLiteralsFetcher.java
+++ b/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/fetchers/telicent/graph/AbstractLiteralsFetcher.java
@@ -14,7 +14,7 @@ package io.telicent.jena.graphql.fetchers.telicent.graph;
 
 import graphql.schema.DataFetchingEnvironment;
 import io.telicent.jena.graphql.schemas.telicent.graph.models.TelicentGraphNode;
-import io.telicent.jena.graphql.schemas.telicent.graph.models.inputs.AbstractFilter;
+import io.telicent.jena.graphql.schemas.telicent.graph.models.inputs.Filter;
 import org.apache.jena.graph.Node;
 import org.apache.jena.sparql.core.DatasetGraph;
 import org.apache.jena.sparql.core.Quad;
@@ -37,7 +37,7 @@ public abstract class AbstractLiteralsFetcher<TOutput>
     }
 
     @Override
-    protected Stream<Quad> select(DataFetchingEnvironment environment, DatasetGraph dsg, TelicentGraphNode node, List<AbstractFilter> filters) {
+    protected Stream<Quad> select(DataFetchingEnvironment environment, DatasetGraph dsg, TelicentGraphNode node, List<Filter> filters) {
         // NB - Filtering not enabled for literals
         return dsg.stream(Node.ANY, node.getNode(), Node.ANY, Node.ANY).filter(q -> q.getObject().isLiteral());
     }

--- a/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/fetchers/telicent/graph/AbstractNodeTypesFetcher.java
+++ b/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/fetchers/telicent/graph/AbstractNodeTypesFetcher.java
@@ -14,7 +14,7 @@ package io.telicent.jena.graphql.fetchers.telicent.graph;
 
 import graphql.schema.DataFetchingEnvironment;
 import io.telicent.jena.graphql.schemas.telicent.graph.models.TelicentGraphNode;
-import io.telicent.jena.graphql.schemas.telicent.graph.models.inputs.AbstractFilter;
+import io.telicent.jena.graphql.schemas.telicent.graph.models.inputs.Filter;
 import org.apache.jena.graph.Node;
 import org.apache.jena.sparql.core.DatasetGraph;
 import org.apache.jena.sparql.core.Quad;
@@ -40,7 +40,7 @@ public abstract class AbstractNodeTypesFetcher<TOutput>
 
     @Override
     protected Stream<Node> select(DataFetchingEnvironment environment, DatasetGraph dsg, TelicentGraphNode node,
-                                  List<AbstractFilter> filters) {
+                                  List<Filter> filters) {
         // NB - Filters not enabled for node types
         return dsg.stream(Node.ANY, node.getNode(), RDF.type.asNode(), Node.ANY)
                   .map(Quad::getObject)

--- a/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/fetchers/telicent/graph/AbstractPagingFetcher.java
+++ b/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/fetchers/telicent/graph/AbstractPagingFetcher.java
@@ -200,8 +200,7 @@ public abstract class AbstractPagingFetcher<TSource, TInput, TOutput> implements
             return IncludeAllFilter.INSTANCE;
         }
         if (rawFilter instanceof Map<?, ?> rawMap) {
-            @SuppressWarnings("unchecked")
-            Map<String, Object> filterMap = (Map<String, Object>) rawMap;
+            @SuppressWarnings("unchecked") Map<String, Object> filterMap = (Map<String, Object>) rawMap;
             FilterMode mode = filterMap.containsKey(TelicentGraphSchema.ARGUMENT_MODE) ?
                               FilterMode.valueOf(filterMap.get(TelicentGraphSchema.ARGUMENT_MODE).toString()) :
                               FilterMode.INCLUDE;
@@ -245,10 +244,40 @@ public abstract class AbstractPagingFetcher<TSource, TInput, TOutput> implements
         return switch (argument) {
             case TelicentGraphSchema.ARGUMENT_TYPE_FILTER -> createTypeFilter(mode, values);
             case TelicentGraphSchema.ARGUMENT_PREDICATE_FILTER -> new PredicateFilter(mode, values);
-            case TelicentGraphSchema.ARGUMENT_DOMAIN_FILTER -> new SubjectFilter(mode, values);
-            case TelicentGraphSchema.ARGUMENT_RANGE_FILTER -> new ObjectFilter(mode, values);
+            case TelicentGraphSchema.ARGUMENT_DOMAIN_FILTER -> createDomainFilter(mode, values);
+            case TelicentGraphSchema.ARGUMENT_RANGE_FILTER -> createRangeFilter(mode, values);
             default -> throw new IllegalArgumentException("Unknown filter argument: " + argument);
         };
+    }
+
+    /**
+     * Creates a range filter
+     * <p>
+     * By default, this is an {@link ObjectFilter} <strong>but</strong> if an implementation traverses the graph in a
+     * different direction it may wish to override this default.
+     * </p>
+     *
+     * @param mode   Filter Mode
+     * @param values Filter values
+     * @return Filter
+     */
+    protected Filter createRangeFilter(FilterMode mode, List<Node> values) {
+        return new ObjectFilter(mode, values);
+    }
+
+    /**
+     * Creates a domain filter
+     * <p>
+     * By default, this is an {@link SubjectFilter} <strong>but</strong> if an implementation traverses the graph in a
+     * different direction it may wish to override this default.
+     * </p>
+     *
+     * @param mode   Filter Mode
+     * @param values Filter values
+     * @return Filter
+     */
+    protected Filter createDomainFilter(FilterMode mode, List<Node> values) {
+        return new SubjectFilter(mode, values);
     }
 
     /**

--- a/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/fetchers/telicent/graph/AbstractPagingFetcher.java
+++ b/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/fetchers/telicent/graph/AbstractPagingFetcher.java
@@ -66,6 +66,7 @@ public abstract class AbstractPagingFetcher<TSource, TInput, TOutput> implements
         List<Filter> filters = new ArrayList<>();
         if (this.enableFilters()) {
             createFilters(environment, filters);
+            filters.removeIf(f -> f instanceof IncludeAllFilter);
         }
 
         return Txn.calculateRead(dsg, () -> {

--- a/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/fetchers/telicent/graph/AbstractPagingFetcher.java
+++ b/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/fetchers/telicent/graph/AbstractPagingFetcher.java
@@ -90,8 +90,7 @@ public abstract class AbstractPagingFetcher<TSource, TInput, TOutput> implements
      */
     protected void createFilters(DataFetchingEnvironment environment, List<Filter> filters) {
         filters.add(this.parseFilter(environment, TelicentGraphSchema.ARGUMENT_PREDICATE_FILTER));
-        filters.add(this.parseFilter(environment, TelicentGraphSchema.ARGUMENT_DOMAIN_FILTER));
-        filters.add(this.parseFilter(environment, TelicentGraphSchema.ARGUMENT_RANGE_FILTER));
+        filters.add(this.parseFilter(environment, TelicentGraphSchema.ARGUMENT_NODE_FILTER));
         filters.add(this.parseFilter(environment, TelicentGraphSchema.ARGUMENT_TYPE_FILTER));
     }
 
@@ -244,14 +243,13 @@ public abstract class AbstractPagingFetcher<TSource, TInput, TOutput> implements
         return switch (argument) {
             case TelicentGraphSchema.ARGUMENT_TYPE_FILTER -> createTypeFilter(mode, values);
             case TelicentGraphSchema.ARGUMENT_PREDICATE_FILTER -> new PredicateFilter(mode, values);
-            case TelicentGraphSchema.ARGUMENT_DOMAIN_FILTER -> createDomainFilter(mode, values);
-            case TelicentGraphSchema.ARGUMENT_RANGE_FILTER -> createRangeFilter(mode, values);
+            case TelicentGraphSchema.ARGUMENT_NODE_FILTER -> createNodeFilter(mode, values);
             default -> throw new IllegalArgumentException("Unknown filter argument: " + argument);
         };
     }
 
     /**
-     * Creates a range filter
+     * Creates a node filter
      * <p>
      * By default, this is an {@link ObjectFilter} <strong>but</strong> if an implementation traverses the graph in a
      * different direction it may wish to override this default.
@@ -261,23 +259,8 @@ public abstract class AbstractPagingFetcher<TSource, TInput, TOutput> implements
      * @param values Filter values
      * @return Filter
      */
-    protected Filter createRangeFilter(FilterMode mode, List<Node> values) {
+    protected Filter createNodeFilter(FilterMode mode, List<Node> values) {
         return new ObjectFilter(mode, values);
-    }
-
-    /**
-     * Creates a domain filter
-     * <p>
-     * By default, this is an {@link SubjectFilter} <strong>but</strong> if an implementation traverses the graph in a
-     * different direction it may wish to override this default.
-     * </p>
-     *
-     * @param mode   Filter Mode
-     * @param values Filter values
-     * @return Filter
-     */
-    protected Filter createDomainFilter(FilterMode mode, List<Node> values) {
-        return new SubjectFilter(mode, values);
     }
 
     /**

--- a/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/fetchers/telicent/graph/AbstractRelationshipsFetcher.java
+++ b/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/fetchers/telicent/graph/AbstractRelationshipsFetcher.java
@@ -72,15 +72,9 @@ public abstract class AbstractRelationshipsFetcher<TOutput>
     }
 
     @Override
-    protected Filter createRangeFilter(FilterMode mode, List<Node> values) {
-        return this.direction == EdgeDirection.OUT ? super.createRangeFilter(mode, values) :
+    protected Filter createNodeFilter(FilterMode mode, List<Node> values) {
+        return this.direction == EdgeDirection.OUT ? super.createNodeFilter(mode, values) :
                new SubjectFilter(mode, values);
-    }
-
-    @Override
-    protected Filter createDomainFilter(FilterMode mode, List<Node> values) {
-        return this.direction == EdgeDirection.OUT ? super.createDomainFilter(mode, values) :
-               new ObjectFilter(mode, values);
     }
 
     @Override

--- a/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/fetchers/telicent/graph/AbstractRelationshipsFetcher.java
+++ b/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/fetchers/telicent/graph/AbstractRelationshipsFetcher.java
@@ -17,10 +17,12 @@ import io.telicent.jena.graphql.schemas.models.EdgeDirection;
 import io.telicent.jena.graphql.schemas.telicent.graph.models.TelicentGraphNode;
 import io.telicent.jena.graphql.schemas.telicent.graph.models.inputs.*;
 import org.apache.commons.collections4.CollectionUtils;
+import org.apache.jena.atlas.lib.tuple.Tuple4;
 import org.apache.jena.graph.Node;
 import org.apache.jena.sparql.core.DatasetGraph;
 import org.apache.jena.sparql.core.Quad;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
@@ -58,7 +60,7 @@ public abstract class AbstractRelationshipsFetcher<TOutput>
     }
 
     @Override
-    protected AbstractFilter createTypeFilter(FilterMode mode, Collection<Node> values) {
+    protected Filter createTypeFilter(FilterMode mode, Collection<Node> values) {
         return switch (this.direction) {
             case IN -> new InboundTypeFilter(mode, values);
             case OUT -> new OutboundTypeFilter(mode, values);
@@ -67,11 +69,11 @@ public abstract class AbstractRelationshipsFetcher<TOutput>
 
     @Override
     protected Stream<Quad> select(DataFetchingEnvironment environment, DatasetGraph dsg, TelicentGraphNode node,
-                                  List<AbstractFilter> filters) {
+                                  List<Filter> filters) {
         // If a Predicate INCLUDE filter can do a more targeted initial stream
-        Set<Node> predicates = getPreFilter(filters);
-        Stream<Quad> quads = predicates != null ? streamPreFiltered(dsg, node, predicates) : stream(dsg, node);
-        for (AbstractFilter filter : filters) {
+        List<Tuple4<Node>> quadPatterns = getPreFilter(filters, node);
+        Stream<Quad> quads = quadPatterns != null ? streamPreFiltered(dsg, node, quadPatterns) : stream(dsg, node);
+        for (Filter filter : filters) {
             quads = filter.filter(quads, dsg);
         }
         return quads;
@@ -97,40 +99,59 @@ public abstract class AbstractRelationshipsFetcher<TOutput>
     }
 
     /**
-     * Gets the predicate pre-filter if any
+     * Gets the pre-filter (if any)
      *
      * @param filters Filters that apply
-     * @return Pre-filter predicates values, or {@code null} if no eligible filter
+     * @return Pre-filter quad patterns, or {@code null} if no eligible filters
      */
-    private Set<Node> getPreFilter(List<AbstractFilter> filters) {
+    private List<Tuple4<Node>> getPreFilter(List<Filter> filters, TelicentGraphNode node) {
         if (CollectionUtils.isEmpty(filters)) {
             return null;
         }
-        if (filters.get(0) instanceof PredicateFilter predicateFilter && predicateFilter.mode() == FilterMode.INCLUDE) {
-            filters.remove(0);
-            return predicateFilter.values();
+        List<Filter> copy = new ArrayList<>(filters);
+        List<Tuple4<Node>> quadPatterns = null;
+        for (Filter filter : copy) {
+            if (filter instanceof QuadPatternFilter quadPatternFilter) {
+                List<Tuple4<Node>> patterns = quadPatternFilter.getQuadPatterns(Node.ANY,
+                                                                                this.direction == EdgeDirection.OUT ?
+                                                                                node.getNode() : Node.ANY, Node.ANY,
+                                                                                this.direction == EdgeDirection.IN ?
+                                                                                node.getNode() : Node.ANY);
+                if (CollectionUtils.isNotEmpty(patterns)) {
+                    // Remove from original list of filters as we're applying it as a pre-filter so no need to apply
+                    // again as a post-filter
+                    filters.remove(filter);
+
+                    // Combine with existing pre-filters (if any)
+                    if (quadPatterns == null) {
+                        quadPatterns = patterns;
+                    } else {
+                        quadPatterns = QuadPatternFilter.combinePatterns(quadPatterns, patterns);
+                    }
+                }
+            }
         }
-        return null;
+        return quadPatterns;
     }
 
     /**
-     * Streams all relationships that lead to another node using specific predicates
+     * Streams all relationships that lead to another node using specific quad patterns
+     * <p>
+     * This is called only if one/more {@link QuadPatternFilter}'s are being used in which case it is more efficient to
+     * directly query for those specific quad patterns than it is to query for all quads and then filter afterward. This
+     * is especially true for nodes in the graph that have lots of relationships.
+     * </p>
      *
-     * @param dsg        Dataset Graph
-     * @param node       Starting Node
-     * @param predicates Predicates
+     * @param dsg          Dataset Graph
+     * @param node         Starting Node
+     * @param quadPatterns Quad patterns to use
      * @return Stream of quads representing relationships
      */
-    private Stream<Quad> streamPreFiltered(DatasetGraph dsg, TelicentGraphNode node, Set<Node> predicates) {
-        // If we're only including specific predicates it's more efficient to only select quads involving those
-        // predicates than it is to select all quads and then filter
+    private Stream<Quad> streamPreFiltered(DatasetGraph dsg, TelicentGraphNode node, List<Tuple4<Node>> quadPatterns) {
+        Stream<Quad> stream = quadPatterns.stream().flatMap(p -> dsg.stream(p.get(0), p.get(1), p.get(2), p.get(3)));
         return switch (this.direction) {
-            case OUT -> predicates.stream()
-                                  .flatMap(p -> dsg.stream(Node.ANY, node.getNode(), p, Node.ANY)
-                                                   .filter(q -> q.getObject().isURI() || q.getObject().isBlank()));
-            case IN -> predicates.stream()
-                                 .flatMap(p -> dsg.stream(Node.ANY, Node.ANY, p, node.getNode())
-                                                  .filter(q -> q.getSubject().isURI() || q.getSubject().isBlank()));
+            case OUT -> stream.filter(q -> q.getObject().isURI() || q.getObject().isBlank());
+            case IN -> stream.filter(q -> q.getSubject().isURI() || q.getSubject().isBlank());
         };
     }
 }

--- a/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/fetchers/telicent/graph/AbstractRelationshipsFetcher.java
+++ b/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/fetchers/telicent/graph/AbstractRelationshipsFetcher.java
@@ -1,11 +1,11 @@
 /**
  * Copyright (C) Telicent Ltd
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
- *
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
@@ -21,11 +21,13 @@ import org.apache.jena.atlas.lib.tuple.Tuple4;
 import org.apache.jena.graph.Node;
 import org.apache.jena.sparql.core.DatasetGraph;
 import org.apache.jena.sparql.core.Quad;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
@@ -35,6 +37,8 @@ import java.util.stream.Stream;
  */
 public abstract class AbstractRelationshipsFetcher<TOutput>
         extends AbstractPagingFetcher<TelicentGraphNode, Quad, TOutput> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(AbstractRelationshipsFetcher.class);
+
     /**
      * The direction of relationships we're configured to fetch
      */
@@ -148,6 +152,12 @@ public abstract class AbstractRelationshipsFetcher<TOutput>
      * @return Stream of quads representing relationships
      */
     private Stream<Quad> streamPreFiltered(DatasetGraph dsg, TelicentGraphNode node, List<Tuple4<Node>> quadPatterns) {
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("Translated pre-filter eligible filters into following {} Quad Patterns:\n  {}",
+                         quadPatterns.size(),
+                         quadPatterns.stream().map(Object::toString).collect(Collectors.joining("\n  ")));
+        }
+
         Stream<Quad> stream = quadPatterns.stream().flatMap(p -> dsg.stream(p.get(0), p.get(1), p.get(2), p.get(3)));
         return switch (this.direction) {
             case OUT -> stream.filter(q -> q.getObject().isURI() || q.getObject().isBlank());

--- a/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/fetchers/telicent/graph/AbstractRelationshipsFetcher.java
+++ b/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/fetchers/telicent/graph/AbstractRelationshipsFetcher.java
@@ -1,11 +1,11 @@
 /**
  * Copyright (C) Telicent Ltd
- * <p>
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
- * <p>
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
@@ -69,6 +69,18 @@ public abstract class AbstractRelationshipsFetcher<TOutput>
             case IN -> new InboundTypeFilter(mode, values);
             case OUT -> new OutboundTypeFilter(mode, values);
         };
+    }
+
+    @Override
+    protected Filter createRangeFilter(FilterMode mode, List<Node> values) {
+        return this.direction == EdgeDirection.OUT ? super.createRangeFilter(mode, values) :
+               new SubjectFilter(mode, values);
+    }
+
+    @Override
+    protected Filter createDomainFilter(FilterMode mode, List<Node> values) {
+        return this.direction == EdgeDirection.OUT ? super.createDomainFilter(mode, values) :
+               new ObjectFilter(mode, values);
     }
 
     @Override

--- a/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/fetchers/telicent/graph/AbstractStateRelationshipsFetcher.java
+++ b/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/fetchers/telicent/graph/AbstractStateRelationshipsFetcher.java
@@ -15,7 +15,7 @@ package io.telicent.jena.graphql.fetchers.telicent.graph;
 import graphql.com.google.common.collect.Streams;
 import graphql.schema.DataFetchingEnvironment;
 import io.telicent.jena.graphql.schemas.telicent.graph.models.State;
-import io.telicent.jena.graphql.schemas.telicent.graph.models.inputs.AbstractFilter;
+import io.telicent.jena.graphql.schemas.telicent.graph.models.inputs.Filter;
 import org.apache.jena.graph.Node;
 import org.apache.jena.sparql.core.DatasetGraph;
 import org.apache.jena.sparql.core.Quad;
@@ -54,7 +54,7 @@ public abstract class AbstractStateRelationshipsFetcher<TOutput>
     }
 
     @Override
-    protected Stream<Quad> select(DataFetchingEnvironment environment, DatasetGraph dsg, State state, List<AbstractFilter> filters) {
+    protected Stream<Quad> select(DataFetchingEnvironment environment, DatasetGraph dsg, State state, List<Filter> filters) {
         // NB - Filters not enabled for state relationships
         return Streams.concat(AbstractStateRelationshipsFetcher.outbound(dsg, state),
                               AbstractStateRelationshipsFetcher.inbound(dsg, state));

--- a/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/schemas/telicent/graph/TelicentGraphSchema.java
+++ b/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/schemas/telicent/graph/TelicentGraphSchema.java
@@ -159,6 +159,14 @@ public class TelicentGraphSchema {
      */
     public static final String ARGUMENT_TYPE_FILTER = "typeFilter";
     /**
+     * Range filter argument used to specify a range filter
+     */
+    public static final String ARGUMENT_RANGE_FILTER = "rangeFilter";
+    /**
+     * Domain filter argument used to specify a domain filter
+     */
+    public static final String ARGUMENT_DOMAIN_FILTER = "domainFilter";
+    /**
      * Type field
      */
     public static final String FIELD_TYPE = "type";

--- a/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/schemas/telicent/graph/TelicentGraphSchema.java
+++ b/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/schemas/telicent/graph/TelicentGraphSchema.java
@@ -159,13 +159,9 @@ public class TelicentGraphSchema {
      */
     public static final String ARGUMENT_TYPE_FILTER = "typeFilter";
     /**
-     * Range filter argument used to specify a range filter
+     * Node filter argument used to specify a node filter on relationships
      */
-    public static final String ARGUMENT_RANGE_FILTER = "rangeFilter";
-    /**
-     * Domain filter argument used to specify a domain filter
-     */
-    public static final String ARGUMENT_DOMAIN_FILTER = "domainFilter";
+    public static final String ARGUMENT_NODE_FILTER = "nodeFilter";
     /**
      * Type field
      */

--- a/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/schemas/telicent/graph/models/inputs/AbstractFilter.java
+++ b/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/schemas/telicent/graph/models/inputs/AbstractFilter.java
@@ -23,9 +23,9 @@ import java.util.Set;
 import java.util.stream.Stream;
 
 /**
- * Abstract class for filters
+ * Abstract implementation of a query filter
  */
-public abstract class AbstractFilter {
+public abstract class AbstractFilter implements Filter {
     /**
      * The filter mode
      */
@@ -42,34 +42,20 @@ public abstract class AbstractFilter {
      * @param values Values to filter by
      */
     public AbstractFilter(FilterMode mode, Collection<Node> values) {
-        this.mode = mode;
-        this.values.addAll(Objects.requireNonNull(values));
+        this.mode = Objects.requireNonNull(mode, "mode cannot be null");
+        this.values.addAll(Objects.requireNonNull(values, "Values to filter by cannot be null"));
+        if (this.values.isEmpty()) {
+            throw new IllegalArgumentException("Values to filter by cannot be empty");
+        }
     }
 
-    /**
-     * Gets the filter mode
-     *
-     * @return Filter mode
-     */
+    @Override
     public FilterMode mode() {
         return this.mode;
     }
 
-    /**
-     * Gets the filter values
-     *
-     * @return Values to filter by
-     */
+    @Override
     public Set<Node> values() {
         return this.values;
     }
-
-    /**
-     * Applies the filter
-     *
-     * @param stream Input stream
-     * @param dsg    Dataset graph
-     * @return Filtered stream
-     */
-    public abstract Stream<Quad> filter(Stream<Quad> stream, DatasetGraph dsg);
 }

--- a/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/schemas/telicent/graph/models/inputs/AbstractFilter.java
+++ b/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/schemas/telicent/graph/models/inputs/AbstractFilter.java
@@ -13,14 +13,11 @@
 package io.telicent.jena.graphql.schemas.telicent.graph.models.inputs;
 
 import org.apache.jena.graph.Node;
-import org.apache.jena.sparql.core.DatasetGraph;
-import org.apache.jena.sparql.core.Quad;
 
 import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.Objects;
 import java.util.Set;
-import java.util.stream.Stream;
 
 /**
  * Abstract implementation of a query filter

--- a/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/schemas/telicent/graph/models/inputs/Filter.java
+++ b/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/schemas/telicent/graph/models/inputs/Filter.java
@@ -16,39 +16,33 @@ import org.apache.jena.graph.Node;
 import org.apache.jena.sparql.core.DatasetGraph;
 import org.apache.jena.sparql.core.Quad;
 
-import java.util.Collections;
 import java.util.Set;
 import java.util.stream.Stream;
 
 /**
- * A no-op filter that includes everything
+ * Interface for GraphQL query filters
  */
-public final class IncludeAllFilter implements Filter {
+public interface Filter {
+    /**
+     * Filter mode
+     *
+     * @return Mode
+     */
+    FilterMode mode();
 
     /**
-     * Singleton instance of the include all filter
+     * Values to filter by
+     *
+     * @return Values
      */
-    public static final Filter INSTANCE = new IncludeAllFilter();
+    Set<Node> values();
 
     /**
-     * Creates a new include all filter
+     * Applies the filter to the given stream
+     *
+     * @param stream Input stream
+     * @param dsg    Dataset graph
+     * @return Filtered stream
      */
-    private IncludeAllFilter() {
-
-    }
-
-    @Override
-    public FilterMode mode() {
-        return FilterMode.INCLUDE;
-    }
-
-    @Override
-    public Set<Node> values() {
-        return Set.of();
-    }
-
-    @Override
-    public Stream<Quad> filter(Stream<Quad> stream, DatasetGraph dsg) {
-        return stream;
-    }
+    Stream<Quad> filter(Stream<Quad> stream, DatasetGraph dsg);
 }

--- a/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/schemas/telicent/graph/models/inputs/IncludeAllFilter.java
+++ b/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/schemas/telicent/graph/models/inputs/IncludeAllFilter.java
@@ -16,7 +16,6 @@ import org.apache.jena.graph.Node;
 import org.apache.jena.sparql.core.DatasetGraph;
 import org.apache.jena.sparql.core.Quad;
 
-import java.util.Collections;
 import java.util.Set;
 import java.util.stream.Stream;
 

--- a/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/schemas/telicent/graph/models/inputs/ObjectFilter.java
+++ b/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/schemas/telicent/graph/models/inputs/ObjectFilter.java
@@ -15,41 +15,37 @@ package io.telicent.jena.graphql.schemas.telicent.graph.models.inputs;
 import org.apache.jena.atlas.lib.tuple.Tuple4;
 import org.apache.jena.atlas.lib.tuple.TupleFactory;
 import org.apache.jena.graph.Node;
-import org.apache.jena.sparql.core.DatasetGraph;
 import org.apache.jena.sparql.core.Quad;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
-import java.util.stream.Stream;
 
 /**
- * A filter that keeps only quads with matching predicates
+ * A filter that includes/excludes only quads with specific objects
  */
-public class PredicateFilter extends QuadFieldFilter implements QuadPatternFilter {
-
+public class ObjectFilter extends QuadFieldFilter implements QuadPatternFilter {
     /**
-     * Creates a new predicate filter
+     * Creates a new object filter
      *
-     * @param mode   Filter mode
-     * @param values Predicate values
+     * @param mode   Filter Mode
+     * @param values Objects to filter by
      */
-    public PredicateFilter(FilterMode mode, Collection<Node> values) {
-        super(mode, values, Quad::getPredicate);
+    public ObjectFilter(FilterMode mode, Collection<Node> values) {
+        super(mode, values, Quad::getObject);
     }
 
     @Override
     public List<Tuple4<Node>> getQuadPatterns(Node graph, Node subject, Node predicate, Node object) {
         if (this.mode == FilterMode.EXCLUDE) return List.of();
 
-        if (predicate != Node.ANY) {
-            throw new IllegalArgumentException("predicate term MUST be ANY");
+        if (object != Node.ANY) {
+            throw new IllegalArgumentException("object term MUST be ANY");
         }
 
         List<Tuple4<Node>> patterns = new ArrayList<>();
-        for (Node predicateFilter : this.values) {
-            patterns.add(TupleFactory.create4(graph, subject, predicateFilter, object));
+        for (Node objectFilter : this.values) {
+            patterns.add(TupleFactory.create4(graph, subject, predicate, objectFilter));
         }
         return patterns;
     }

--- a/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/schemas/telicent/graph/models/inputs/PredicateFilter.java
+++ b/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/schemas/telicent/graph/models/inputs/PredicateFilter.java
@@ -15,14 +15,11 @@ package io.telicent.jena.graphql.schemas.telicent.graph.models.inputs;
 import org.apache.jena.atlas.lib.tuple.Tuple4;
 import org.apache.jena.atlas.lib.tuple.TupleFactory;
 import org.apache.jena.graph.Node;
-import org.apache.jena.sparql.core.DatasetGraph;
 import org.apache.jena.sparql.core.Quad;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
-import java.util.stream.Stream;
 
 /**
  * A filter that keeps only quads with matching predicates

--- a/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/schemas/telicent/graph/models/inputs/QuadPatternFilter.java
+++ b/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/schemas/telicent/graph/models/inputs/QuadPatternFilter.java
@@ -22,7 +22,7 @@ import java.util.List;
 /**
  * Interface for filters whose filter condition can be expressed as one/more simple quad patterns
  */
-public interface QuadPatternFilter {
+public interface QuadPatternFilter extends Filter {
 
     /**
      * Gets the quad patterns that this filter represents if applicable
@@ -66,6 +66,8 @@ public interface QuadPatternFilter {
         if (leftNode == Node.ANY) {
             return rightNode;
         } else if (rightNode == Node.ANY) {
+            return leftNode;
+        } else if (leftNode.equals(rightNode)) {
             return leftNode;
         } else {
             throw new IllegalArgumentException(

--- a/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/schemas/telicent/graph/models/inputs/QuadPatternFilter.java
+++ b/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/schemas/telicent/graph/models/inputs/QuadPatternFilter.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright (C) Telicent Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.telicent.jena.graphql.schemas.telicent.graph.models.inputs;
+
+import org.apache.jena.atlas.lib.tuple.Tuple4;
+import org.apache.jena.atlas.lib.tuple.TupleFactory;
+import org.apache.jena.graph.Node;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Interface for filters whose filter condition can be expressed as one/more simple quad patterns
+ */
+public interface QuadPatternFilter {
+
+    /**
+     * Gets the quad patterns that this filter represents if applicable
+     * <p>
+     * Generally this is only applicable for filters that
+     * </p>
+     *
+     * @param graph     Default graph filter term
+     * @param subject   Default subject filter term
+     * @param predicate Default predicate filter term
+     * @param object    Default object filter term
+     * @return Quad Patterns
+     * @throws IllegalArgumentException If one of the given default terms conflicts with the filter, typically this
+     *                                  happens if you supply something other than {@link Node#ANY} in a position that
+     *                                  the filter wants to filter on.
+     */
+    List<Tuple4<Node>> getQuadPatterns(Node graph, Node subject, Node predicate, Node object);
+
+    /**
+     * Combines two sets of patterns together to yield all the pattern combinations
+     *
+     * @param a First set of patterns
+     * @param b Second set of patterns
+     * @return Combined patterns
+     */
+    static List<Tuple4<Node>> combinePatterns(List<Tuple4<Node>> a, List<Tuple4<Node>> b) {
+        List<Tuple4<Node>> combined = new ArrayList<>();
+        for (Tuple4<Node> left : a) {
+            for (Tuple4<Node> right : b) {
+                combined.add(
+                        TupleFactory.create4(combine(left, right, 0), combine(left, right, 1), combine(left, right, 2),
+                                             combine(left, right, 3)));
+            }
+        }
+        return combined;
+    }
+
+    private static Node combine(Tuple4<Node> left, Tuple4<Node> right, int index) {
+        Node leftNode = left.get(index);
+        Node rightNode = right.get(index);
+        if (leftNode == Node.ANY) {
+            return rightNode;
+        } else if (rightNode == Node.ANY) {
+            return leftNode;
+        } else {
+            throw new IllegalArgumentException(
+                    "Both patterns have conflicting concrete values in the " + position(index) + " position");
+        }
+    }
+
+    private static String position(int i) {
+        return switch (i) {
+            case 0 -> "Graph";
+            case 1 -> "Subject";
+            case 2 -> "Predicate";
+            case 3 -> "Object";
+            default -> "Unknown";
+        };
+    }
+
+}

--- a/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/schemas/telicent/graph/models/inputs/SubjectFilter.java
+++ b/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/schemas/telicent/graph/models/inputs/SubjectFilter.java
@@ -15,41 +15,37 @@ package io.telicent.jena.graphql.schemas.telicent.graph.models.inputs;
 import org.apache.jena.atlas.lib.tuple.Tuple4;
 import org.apache.jena.atlas.lib.tuple.TupleFactory;
 import org.apache.jena.graph.Node;
-import org.apache.jena.sparql.core.DatasetGraph;
 import org.apache.jena.sparql.core.Quad;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
-import java.util.stream.Stream;
 
 /**
- * A filter that keeps only quads with matching predicates
+ * A filter that includes/excludes only quads with specific subjects
  */
-public class PredicateFilter extends QuadFieldFilter implements QuadPatternFilter {
-
+public class SubjectFilter extends QuadFieldFilter implements QuadPatternFilter {
     /**
-     * Creates a new predicate filter
+     * Creates a new subject filter
      *
-     * @param mode   Filter mode
-     * @param values Predicate values
+     * @param mode   Filter Mode
+     * @param values Subjects to filter by
      */
-    public PredicateFilter(FilterMode mode, Collection<Node> values) {
-        super(mode, values, Quad::getPredicate);
+    public SubjectFilter(FilterMode mode, Collection<Node> values) {
+        super(mode, values, Quad::getSubject);
     }
 
     @Override
     public List<Tuple4<Node>> getQuadPatterns(Node graph, Node subject, Node predicate, Node object) {
         if (this.mode == FilterMode.EXCLUDE) return List.of();
 
-        if (predicate != Node.ANY) {
-            throw new IllegalArgumentException("predicate term MUST be ANY");
+        if (subject != Node.ANY) {
+            throw new IllegalArgumentException("subject term MUST be ANY");
         }
 
         List<Tuple4<Node>> patterns = new ArrayList<>();
-        for (Node predicateFilter : this.values) {
-            patterns.add(TupleFactory.create4(graph, subject, predicateFilter, object));
+        for (Node subjectFilter : this.values) {
+            patterns.add(TupleFactory.create4(graph, subjectFilter, predicate, object));
         }
         return patterns;
     }

--- a/telicent-graph-schema/src/main/resources/io/telicent/jena/graphql/schemas/telicent/graph/ies.graphqls
+++ b/telicent-graph-schema/src/main/resources/io/telicent/jena/graphql/schemas/telicent/graph/ies.graphqls
@@ -5,8 +5,8 @@ type Node {
     shortUri: String! # If a shortened (namespace prefixed) form of the uri is available, otherwise returns full uri
     types(limit: Int = 50, offset: Int = 1): [Node]! # An array of types for the Node - i.e. the classes it is an instance of.
     properties(limit: Int = 50, offset: Int = 1): [Property]! # An array of literal properties of the Node
-    outRels(limit: Int = 50, offset: Int = 1, predicateFilter: UriFilter, typeFilter: UriFilter): [Rel]! # An array of Rels where the current Node is in the domain position
-    inRels(limit: Int = 50, offset: Int = 1, predicateFilter: UriFilter, typeFilter: UriFilter): [Rel]! # An array of Rels where the current Node is in the range position
+    outRels(limit: Int = 50, offset: Int = 1, predicateFilter: UriFilter, typeFilter: UriFilter, rangeFilter: UriFilter): [Rel]! # An array of Rels where the current Node is in the domain position
+    inRels(limit: Int = 50, offset: Int = 1, predicateFilter: UriFilter, typeFilter: UriFilter, domainFilter: UriFilter): [Rel]! # An array of Rels where the current Node is in the range position
     relCounts: NodeRelCounts! # Relationship counts information
     relFacets: NodeRelFacets!
     instances(limit: Int = 50, offset: Int = 1): [Node] # If the node is a class, this will return an array of its instances
@@ -22,8 +22,8 @@ type Rel { # A subject-predicate-object statement
 }
 
 type NodeRelCounts { # Counts of relationships available for a Node
-    inRels(predicateFilter: UriFilter, typeFilter: UriFilter): Int
-    outRels(predicateFilter: UriFilter, typeFilter: UriFilter): Int
+    inRels(predicateFilter: UriFilter, typeFilter: UriFilter, domainFilter: UriFilter): Int
+    outRels(predicateFilter: UriFilter, typeFilter: UriFilter, rangeFilter: UriFilter): Int
     properties: Int
     types: Int
     instances: Int

--- a/telicent-graph-schema/src/main/resources/io/telicent/jena/graphql/schemas/telicent/graph/ies.graphqls
+++ b/telicent-graph-schema/src/main/resources/io/telicent/jena/graphql/schemas/telicent/graph/ies.graphqls
@@ -6,7 +6,7 @@ type Node {
     types(limit: Int = 50, offset: Int = 1): [Node]! # An array of types for the Node - i.e. the classes it is an instance of.
     properties(limit: Int = 50, offset: Int = 1): [Property]! # An array of literal properties of the Node
     outRels(limit: Int = 50, offset: Int = 1, predicateFilter: UriFilter, typeFilter: UriFilter, rangeFilter: UriFilter): [Rel]! # An array of Rels where the current Node is in the domain position
-    inRels(limit: Int = 50, offset: Int = 1, predicateFilter: UriFilter, typeFilter: UriFilter, domainFilter: UriFilter): [Rel]! # An array of Rels where the current Node is in the range position
+    inRels(limit: Int = 50, offset: Int = 1, predicateFilter: UriFilter, typeFilter: UriFilter, rangeFilter: UriFilter): [Rel]! # An array of Rels where the current Node is in the range position
     relCounts: NodeRelCounts! # Relationship counts information
     relFacets: NodeRelFacets!
     instances(limit: Int = 50, offset: Int = 1): [Node] # If the node is a class, this will return an array of its instances
@@ -22,7 +22,7 @@ type Rel { # A subject-predicate-object statement
 }
 
 type NodeRelCounts { # Counts of relationships available for a Node
-    inRels(predicateFilter: UriFilter, typeFilter: UriFilter, domainFilter: UriFilter): Int
+    inRels(predicateFilter: UriFilter, typeFilter: UriFilter, rangeFilter: UriFilter): Int
     outRels(predicateFilter: UriFilter, typeFilter: UriFilter, rangeFilter: UriFilter): Int
     properties: Int
     types: Int

--- a/telicent-graph-schema/src/main/resources/io/telicent/jena/graphql/schemas/telicent/graph/ies.graphqls
+++ b/telicent-graph-schema/src/main/resources/io/telicent/jena/graphql/schemas/telicent/graph/ies.graphqls
@@ -5,8 +5,8 @@ type Node {
     shortUri: String! # If a shortened (namespace prefixed) form of the uri is available, otherwise returns full uri
     types(limit: Int = 50, offset: Int = 1): [Node]! # An array of types for the Node - i.e. the classes it is an instance of.
     properties(limit: Int = 50, offset: Int = 1): [Property]! # An array of literal properties of the Node
-    outRels(limit: Int = 50, offset: Int = 1, predicateFilter: UriFilter, typeFilter: UriFilter, rangeFilter: UriFilter): [Rel]! # An array of Rels where the current Node is in the domain position
-    inRels(limit: Int = 50, offset: Int = 1, predicateFilter: UriFilter, typeFilter: UriFilter, rangeFilter: UriFilter): [Rel]! # An array of Rels where the current Node is in the range position
+    outRels(limit: Int = 50, offset: Int = 1, predicateFilter: UriFilter, typeFilter: UriFilter, nodeFilter: UriFilter): [Rel]! # An array of Rels where the current Node is in the domain position
+    inRels(limit: Int = 50, offset: Int = 1, predicateFilter: UriFilter, typeFilter: UriFilter, nodeFilter: UriFilter): [Rel]! # An array of Rels where the current Node is in the range position
     relCounts: NodeRelCounts! # Relationship counts information
     relFacets: NodeRelFacets!
     instances(limit: Int = 50, offset: Int = 1): [Node] # If the node is a class, this will return an array of its instances
@@ -22,8 +22,8 @@ type Rel { # A subject-predicate-object statement
 }
 
 type NodeRelCounts { # Counts of relationships available for a Node
-    inRels(predicateFilter: UriFilter, typeFilter: UriFilter, rangeFilter: UriFilter): Int
-    outRels(predicateFilter: UriFilter, typeFilter: UriFilter, rangeFilter: UriFilter): Int
+    inRels(predicateFilter: UriFilter, typeFilter: UriFilter, nodeFilter: UriFilter): Int
+    outRels(predicateFilter: UriFilter, typeFilter: UriFilter, nodeFilter: UriFilter): Int
     properties: Int
     types: Int
     instances: Int

--- a/telicent-graph-schema/src/test/java/io/telicent/jena/graphql/execution/telicent/graph/TestTelicentGraphExecution.java
+++ b/telicent-graph-schema/src/test/java/io/telicent/jena/graphql/execution/telicent/graph/TestTelicentGraphExecution.java
@@ -289,6 +289,10 @@ public class TestTelicentGraphExecution extends AbstractExecutionTests {
         Map<String, Object> birthOrDeathStateTypeFilter =
                 Map.of(TelicentGraphSchema.ARGUMENT_MODE, "INCLUDE", TelicentGraphSchema.ARGUMENT_VALUES,
                        List.of(IesFetchers.iesTerm("BirthState").getURI(), IesFetchers.iesTerm("DeathState").getURI()));
+        Map<String, Object> birthOrDeathNodeFilter =
+                Map.of(TelicentGraphSchema.ARGUMENT_MODE, "INCLUDE", TelicentGraphSchema.ARGUMENT_VALUES,
+                       List.of("https://starwars.com#person_Obi-WanKenobi_BIRTH",
+                               "https://starwars.com#person_Obi-WanKenobi_DEATH"));
 
         return new Object[][] {
                 {
@@ -304,7 +308,11 @@ public class TestTelicentGraphExecution extends AbstractExecutionTests {
                 },
                 // Birth and Death State exists
                 {
-                    Map.of("typeFilter", birthOrDeathStateTypeFilter), 2, 0
+                        Map.of("typeFilter", birthOrDeathStateTypeFilter), 2, 0
+                },
+                // Only relationships involving the Birth or Death State nodes
+                {
+                        Map.of("nodeFilter", birthOrDeathNodeFilter), 2, 0
                 }
         };
     }

--- a/telicent-graph-schema/src/test/java/io/telicent/jena/graphql/fetchers/telicent/graph/TestFilterParsing.java
+++ b/telicent-graph-schema/src/test/java/io/telicent/jena/graphql/fetchers/telicent/graph/TestFilterParsing.java
@@ -16,14 +16,13 @@ import graphql.schema.DataFetchingEnvironment;
 import graphql.schema.DataFetchingEnvironmentImpl;
 import io.telicent.jena.graphql.schemas.telicent.graph.TelicentGraphSchema;
 import io.telicent.jena.graphql.schemas.telicent.graph.models.TelicentGraphNode;
-import io.telicent.jena.graphql.schemas.telicent.graph.models.inputs.AbstractFilter;
+import io.telicent.jena.graphql.schemas.telicent.graph.models.inputs.Filter;
 import io.telicent.jena.graphql.schemas.telicent.graph.models.inputs.IncludeAllFilter;
 import org.apache.jena.sparql.core.DatasetGraph;
 import org.apache.jena.sparql.core.Quad;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -32,7 +31,7 @@ import java.util.stream.Stream;
 public class TestFilterParsing extends AbstractPagingFetcher<TelicentGraphNode, Quad, List<Quad>> {
     @Override
     protected Stream<Quad> select(DataFetchingEnvironment environment, DatasetGraph dsg, TelicentGraphNode node,
-                                  List<AbstractFilter> filters) {
+                                  List<Filter> filters) {
         return Stream.empty();
     }
 
@@ -52,7 +51,7 @@ public class TestFilterParsing extends AbstractPagingFetcher<TelicentGraphNode, 
         DataFetchingEnvironment environment = prepareEnvironment(Collections.emptyMap());
 
         // When
-        AbstractFilter filter = this.parseFilter(environment, TelicentGraphSchema.ARGUMENT_TYPE_FILTER);
+        Filter filter = this.parseFilter(environment, TelicentGraphSchema.ARGUMENT_TYPE_FILTER);
 
         // Then
         Assert.assertTrue(filter instanceof IncludeAllFilter);
@@ -128,7 +127,7 @@ public class TestFilterParsing extends AbstractPagingFetcher<TelicentGraphNode, 
     public void givenTypeFilterWith_filtersDisabled_returnAll() {
         // Given
         // When
-        AbstractFilter result = this.createTypeFilter(null, null);
+        Filter result = this.createTypeFilter(null, null);
         // Then
         Assert.assertEquals(IncludeAllFilter.INSTANCE, result);
     }

--- a/telicent-graph-schema/src/test/java/io/telicent/jena/graphql/fetchers/telicent/graph/TestRelationshipsFetcher.java
+++ b/telicent-graph-schema/src/test/java/io/telicent/jena/graphql/fetchers/telicent/graph/TestRelationshipsFetcher.java
@@ -200,28 +200,19 @@ public class TestRelationshipsFetcher extends AbstractFetcherTests {
                 };
     }
 
-    @DataProvider(name = "outboundRangeFilters")
-    private Object[][] outboundRangeFilters() {
+    @DataProvider(name = "outboundNodeFilters")
+    private Object[][] outboundNodeFilters() {
         return new Object[][] {
                 { "INCLUDE", List.of("object1"), List.of("object1") },
                 { "EXCLUDE", List.of("object1"), List.of("object2", "object3") },
                 };
     }
 
-    @DataProvider(name = "inboundRangeFilters")
-    private Object[][] inboundRangeFilters() {
+    @DataProvider(name = "inboundNodeFilters")
+    private Object[][] inboundNodeFilters() {
         return new Object[][] {
                 { "INCLUDE", List.of("object1"), List.of("object1") },
                 { "EXCLUDE", List.of("object1"), List.of("object2", "object3") },
-                };
-    }
-
-    @DataProvider(name = "domainFilters")
-    private Object[][] domainFilters() {
-        return new Object[][] {
-                { "INCLUDE", List.of("object1", "object3"), List.of("object1", "object3") },
-                { "INCLUDE", List.of("object4"), Collections.emptyList() },
-                { "EXCLUDE", List.of("object3"), List.of("object1", "object2") },
                 };
     }
 
@@ -271,8 +262,8 @@ public class TestRelationshipsFetcher extends AbstractFetcherTests {
                 };
     }
 
-    @DataProvider(name = "predicateAndRangeFilters")
-    private Object[][] predicateAndRangeFilters() {
+    @DataProvider(name = "predicateAndNodeFilters")
+    private Object[][] predicateAndNodeFilters() {
         return new Object[][] {
                 // Includes only predicate 1 and object 1 so only object 1 returned
                 { "INCLUDE", List.of("predicate1"), "INCLUDE", List.of("object1"), List.of("object1") },
@@ -332,28 +323,20 @@ public class TestRelationshipsFetcher extends AbstractFetcherTests {
                                    TelicentGraphSchema.ARGUMENT_TYPE_FILTER, r -> r.getDomain().getUri());
     }
 
-    @Test(dataProvider = "outboundRangeFilters")
-    public void givenGraphWithTypes_whenFetchingRelationshipsWithOutboundRangeFilter_thenOnlyRelationshipsWithRelevantObjectsFetched(
+    @Test(dataProvider = "outboundNodeFilters")
+    public void givenGraphWithTypes_whenFetchingRelationshipsWithOutboundNodeFilter_thenOnlyRelationshipsWithRelevantObjectsFetched(
             String filterMode, List<String> filterValues, List<String> expectedResults) throws Exception {
         // given
         verifyFetchedRelationships(filterMode, filterValues, expectedResults, EdgeDirection.OUT,
-                                   TelicentGraphSchema.ARGUMENT_RANGE_FILTER, r -> r.getRange().getUri());
+                                   TelicentGraphSchema.ARGUMENT_NODE_FILTER, r -> r.getRange().getUri());
     }
 
-    @Test(dataProvider = "inboundRangeFilters")
-    public void givenGraphWithTypes_whenFetchingRelationshipsWithInboundRangeFilter_thenOnlyRelationshipsWithRelevantObjectsFetched(
+    @Test(dataProvider = "inboundNodeFilters")
+    public void givenGraphWithTypes_whenFetchingRelationshipsWithInboundNodeFilter_thenOnlyRelationshipsWithRelevantObjectsFetched(
             String filterMode, List<String> filterValues, List<String> expectedResults) throws Exception {
         // given
         verifyFetchedRelationships(filterMode, filterValues, expectedResults, EdgeDirection.IN,
-                                   TelicentGraphSchema.ARGUMENT_RANGE_FILTER, r -> r.getDomain().getUri());
-    }
-
-    @Test(dataProvider = "domainFilters")
-    public void givenGraphWithTypes_whenFetchingRelationshipsWithDomainFilter_thenOnlyRelationshipsWithRelevantSubjectsFetched(
-            String filterMode, List<String> filterValues, List<String> expectedResults) throws Exception {
-        // given
-        verifyFetchedRelationships(filterMode, filterValues, expectedResults, EdgeDirection.IN,
-                                   TelicentGraphSchema.ARGUMENT_DOMAIN_FILTER, r -> r.getDomain().getUri());
+                                   TelicentGraphSchema.ARGUMENT_NODE_FILTER, r -> r.getDomain().getUri());
     }
 
     @Test(dataProvider = "outboundTypeAndPredicateFilters")
@@ -399,13 +382,13 @@ public class TestRelationshipsFetcher extends AbstractFetcherTests {
         }
     }
 
-    @Test(dataProvider = "predicateAndRangeFilters")
-    public void givenGraphWithTypes_whenFetchingRelationshipsWithPredicateAndRangeFilter_thenOnlyRelationshipsWithRelevantPredicatesAndObjectsFetched(
+    @Test(dataProvider = "predicateAndNodeFilters")
+    public void givenGraphWithTypes_whenFetchingRelationshipsWithPredicateAndNodeFilters_thenOnlyRelationshipsWithRelevantPredicatesAndObjectsFetched(
             String predicateFilterMode, List<String> predicateFilters, String rangeFilterMode, List<String> rangeFilters,
             List<String> expectedResults) throws Exception {
         verifyDualFilterFetchedRelationships(predicateFilterMode, predicateFilters,
                                              TelicentGraphSchema.ARGUMENT_PREDICATE_FILTER, rangeFilterMode, rangeFilters,
-                                             TelicentGraphSchema.ARGUMENT_RANGE_FILTER, expectedResults
+                                             TelicentGraphSchema.ARGUMENT_NODE_FILTER, expectedResults
         );
     }
 

--- a/telicent-graph-schema/src/test/java/io/telicent/jena/graphql/fetchers/telicent/graph/TestRelationshipsFetcher.java
+++ b/telicent-graph-schema/src/test/java/io/telicent/jena/graphql/fetchers/telicent/graph/TestRelationshipsFetcher.java
@@ -1,11 +1,11 @@
 /**
  * Copyright (C) Telicent Ltd
- * <p>
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
- * <p>
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
@@ -200,8 +200,16 @@ public class TestRelationshipsFetcher extends AbstractFetcherTests {
                 };
     }
 
-    @DataProvider(name = "rangeFilters")
-    private Object[][] rangeFilters() {
+    @DataProvider(name = "outboundRangeFilters")
+    private Object[][] outboundRangeFilters() {
+        return new Object[][] {
+                { "INCLUDE", List.of("object1"), List.of("object1") },
+                { "EXCLUDE", List.of("object1"), List.of("object2", "object3") },
+                };
+    }
+
+    @DataProvider(name = "inboundRangeFilters")
+    private Object[][] inboundRangeFilters() {
         return new Object[][] {
                 { "INCLUDE", List.of("object1"), List.of("object1") },
                 { "EXCLUDE", List.of("object1"), List.of("object2", "object3") },
@@ -324,12 +332,20 @@ public class TestRelationshipsFetcher extends AbstractFetcherTests {
                                    TelicentGraphSchema.ARGUMENT_TYPE_FILTER, r -> r.getDomain().getUri());
     }
 
-    @Test(dataProvider = "rangeFilters")
-    public void givenGraphWithTypes_whenFetchingRelationshipsWithRangeFilter_thenOnlyRelationshipsWithRelevantObjectsFetched(
+    @Test(dataProvider = "outboundRangeFilters")
+    public void givenGraphWithTypes_whenFetchingRelationshipsWithOutboundRangeFilter_thenOnlyRelationshipsWithRelevantObjectsFetched(
             String filterMode, List<String> filterValues, List<String> expectedResults) throws Exception {
         // given
         verifyFetchedRelationships(filterMode, filterValues, expectedResults, EdgeDirection.OUT,
                                    TelicentGraphSchema.ARGUMENT_RANGE_FILTER, r -> r.getRange().getUri());
+    }
+
+    @Test(dataProvider = "inboundRangeFilters")
+    public void givenGraphWithTypes_whenFetchingRelationshipsWithInboundRangeFilter_thenOnlyRelationshipsWithRelevantObjectsFetched(
+            String filterMode, List<String> filterValues, List<String> expectedResults) throws Exception {
+        // given
+        verifyFetchedRelationships(filterMode, filterValues, expectedResults, EdgeDirection.IN,
+                                   TelicentGraphSchema.ARGUMENT_RANGE_FILTER, r -> r.getDomain().getUri());
     }
 
     @Test(dataProvider = "domainFilters")

--- a/telicent-graph-schema/src/test/java/io/telicent/jena/graphql/fetchers/telicent/graph/TestRelationshipsFetcher.java
+++ b/telicent-graph-schema/src/test/java/io/telicent/jena/graphql/fetchers/telicent/graph/TestRelationshipsFetcher.java
@@ -1,11 +1,11 @@
 /**
  * Copyright (C) Telicent Ltd
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
- *
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
@@ -32,6 +32,7 @@ import org.testng.annotations.Test;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 
 import static org.apache.jena.graph.NodeFactory.*;
 
@@ -144,19 +145,30 @@ public class TestRelationshipsFetcher extends AbstractFetcherTests {
     }
 
     private static void createTypedGraph(DatasetGraph dsg, Node subject) {
+        Node rdfType = RDF.type.asNode();
+
+        // Subject is related via predicate 1 to object 1 which has types 1 and 2
         Node object1 = createURI("object1");
         dsg.add(new Quad(GRAPH, subject, createURI("predicate1"), object1));
-        dsg.add(new Quad(GRAPH, object1, RDF.type.asNode(), createURI("type1")));
-        dsg.add(new Quad(GRAPH, object1, RDF.type.asNode(), createURI("type2")));
+        dsg.add(new Quad(GRAPH, object1, createURI("predicate1"), subject));
+        dsg.add(new Quad(GRAPH, object1, rdfType, createURI("type1")));
+        dsg.add(new Quad(GRAPH, object1, rdfType, createURI("type2")));
+
+        // Subject is related via predicate 2 to object 2 which has types 1 and 3
         Node object2 = createURI("object2");
         dsg.add(new Quad(GRAPH, subject, createURI("predicate2"), object2));
-        dsg.add(new Quad(GRAPH, object2, RDF.type.asNode(), createURI("type1")));
-        dsg.add(new Quad(GRAPH, object2, RDF.type.asNode(), createURI("type3")));
-        dsg.add(new Quad(GRAPH, subject, createURI("predicate3"), createURI("object3")));
+        dsg.add(new Quad(GRAPH, object2, createURI("predicate2"), subject));
+        dsg.add(new Quad(GRAPH, object2, rdfType, createURI("type1")));
+        dsg.add(new Quad(GRAPH, object2, rdfType, createURI("type3")));
+
+        // Subject is related via predicate 3 to object 3 which has no types
+        Node object3 = createURI("object3");
+        dsg.add(new Quad(GRAPH, subject, createURI("predicate3"), object3));
+        dsg.add(new Quad(GRAPH, object3, createURI("predicate3"), subject));
     }
 
-    @DataProvider(name = "typeFilters")
-    private Object[][] typeFilters() {
+    @DataProvider(name = "outboundTypeFilters")
+    private Object[][] outboundTypeFilters() {
         return new Object[][] {
                 // Both 1 and 2 have type 1
                 { "INCLUDE", List.of("type1"), List.of("object1", "object2") },
@@ -178,8 +190,35 @@ public class TestRelationshipsFetcher extends AbstractFetcherTests {
                 };
     }
 
-    @DataProvider(name = "typeAndPredicateFilters")
-    private Object[][] typeAndPredicateFilters() {
+    @DataProvider(name = "inboundTypeFilters")
+    private Object[][] inboundTypeFilters() {
+        return new Object[][] {
+                // Only subject has type 0
+                { "INCLUDE", List.of("type1"), List.of("object1", "object2") },
+                // No inbound relationships with
+                { "EXCLUDE", List.of("type1"), List.of("object3") },
+                };
+    }
+
+    @DataProvider(name = "rangeFilters")
+    private Object[][] rangeFilters() {
+        return new Object[][] {
+                { "INCLUDE", List.of("object1"), List.of("object1") },
+                { "EXCLUDE", List.of("object1"), List.of("object2", "object3") },
+                };
+    }
+
+    @DataProvider(name = "domainFilters")
+    private Object[][] domainFilters() {
+        return new Object[][] {
+                { "INCLUDE", List.of("object1", "object3"), List.of("object1", "object3") },
+                { "INCLUDE", List.of("object4"), Collections.emptyList() },
+                { "EXCLUDE", List.of("object3"), List.of("object1", "object2") },
+                };
+    }
+
+    @DataProvider(name = "outboundTypeAndPredicateFilters")
+    private Object[][] outboundTypeAndPredicateFilters() {
         return new Object[][] {
                 // Both 1 and 2 have type 1, but only 1 uses predicate 1
                 { "INCLUDE", List.of("predicate1"), "INCLUDE", List.of("type1"), List.of("object1") },
@@ -198,25 +237,69 @@ public class TestRelationshipsFetcher extends AbstractFetcherTests {
                 { "INCLUDE", List.of("predicate3"), "EXCLUDE", List.of("type3"), List.of("object3") },
                 // noSuchType not in graph
                 { "INCLUDE", List.of("predicate1"), "INCLUDE", List.of("noSuchType"), Collections.emptyList() },
-                { "INCLUDE", List.of("predicate1", "predicate3"), "EXCLUDE", List.of("noSuchType"), List.of("object1", "object3") },
+                {
+                        "INCLUDE",
+                        List.of("predicate1", "predicate3"),
+                        "EXCLUDE",
+                        List.of("noSuchType"),
+                        List.of("object1", "object3")
+                },
                 // Only 1 and 2 have types, but since those triples are not directly from our subject returns nothing
-                { "INCLUDE", List.of(RDF.type.getURI()), "INCLUDE", List.of("type1", "type2", "type3"), Collections.emptyList() },
+                {
+                        "INCLUDE",
+                        List.of(RDF.type.getURI()),
+                        "INCLUDE",
+                        List.of("type1", "type2", "type3"),
+                        Collections.emptyList()
+                },
                 // 3 has no types
-                { "INCLUDE", List.of(RDF.type.getURI()), "EXCLUDE", List.of("type1", "type2", "type3"), Collections.emptyList() },
-            };
+                {
+                        "INCLUDE",
+                        List.of(RDF.type.getURI()),
+                        "EXCLUDE",
+                        List.of("type1", "type2", "type3"),
+                        Collections.emptyList()
+                },
+                };
     }
 
-    @Test(dataProvider = "typeFilters")
-    public void givenGraphWithTypes_whenFetchingRelationshipsWithTypeFilter_thenOnlyRelationshipsWithRelevantTypedObjectsFetched(
+    @DataProvider(name = "predicateAndRangeFilters")
+    private Object[][] predicateAndRangeFilters() {
+        return new Object[][] {
+                // Includes only predicate 1 and object 1 so only object 1 returned
+                { "INCLUDE", List.of("predicate1"), "INCLUDE", List.of("object1"), List.of("object1") },
+                // Includes any predicate and objects 1 or 2 so those objects are returned
+                {
+                        "INCLUDE",
+                        List.of("predicate1", "predicate2", "predicate3"),
+                        "INCLUDE",
+                        List.of("object1", "object2"),
+                        List.of("object1", "object2")
+                },
+                // Object 3 is linked via predicate 3 so combining these filters yields nothing
+                { "INCLUDE", List.of("predicate1"), "INCLUDE", List.of("object3"), Collections.emptyList() },
+                };
+    }
+
+    @Test(dataProvider = "outboundTypeFilters")
+    public void givenGraphWithTypes_whenFetchingRelationshipsWithOutboundTypeFilter_thenOnlyRelationshipsWithRelevantTypedObjectsFetched(
             String filterMode, List<String> filterValues, List<String> expectedResults) throws Exception {
+        verifyFetchedRelationships(filterMode, filterValues, expectedResults, EdgeDirection.OUT,
+                                   TelicentGraphSchema.ARGUMENT_TYPE_FILTER, r -> r.getRange().getUri());
+    }
+
+    private static void verifyFetchedRelationships(String filterMode, List<String> filterValues,
+                                                   List<String> expectedResults, EdgeDirection edgeDirection,
+                                                   String filterArgument,
+                                                   Function<Relationship, String> fetchedUriExtractor) throws Exception {
         // given
-        RelationshipsFetcher fetcher = new RelationshipsFetcher(EdgeDirection.OUT);
+        RelationshipsFetcher fetcher = new RelationshipsFetcher(edgeDirection);
         DatasetGraph dsg = DatasetGraphFactory.create();
         Node subject = createURI("subject");
         createTypedGraph(dsg, subject);
 
         DataFetchingEnvironment environment = prepareFetchingEnvironment(dsg, new TelicentGraphNode(subject, null),
-                                                                         Map.of(TelicentGraphSchema.ARGUMENT_TYPE_FILTER,
+                                                                         Map.of(filterArgument,
                                                                                 Map.of(TelicentGraphSchema.ARGUMENT_MODE,
                                                                                        filterMode,
                                                                                        TelicentGraphSchema.ARGUMENT_VALUES,
@@ -229,14 +312,48 @@ public class TestRelationshipsFetcher extends AbstractFetcherTests {
         Assert.assertNotNull(actualList);
         Assert.assertEquals(actualList.size(), expectedResults.size());
         for (String expected : expectedResults) {
-            Assert.assertTrue(actualList.stream().anyMatch(r -> StringUtils.equals(r.getRange().getUri(), expected)));
+            Assert.assertTrue(
+                    actualList.stream().map(fetchedUriExtractor).anyMatch(uri -> StringUtils.equals(uri, expected)));
         }
     }
 
-    @Test(dataProvider = "typeAndPredicateFilters")
-    public void givenGraphWithTypes_whenFetchingRelationshipsWithPredicateAndTypeFilter_thenOnlyRelationshipsWithRelevantPredicatesAndTypedObjectsFetched(
+    @Test(dataProvider = "inboundTypeFilters")
+    public void givenGraphWithTypes_whenFetchingRelationshipsWithInboundTypeFilter_thenOnlyRelationshipsWithRelevantTypedObjectsFetched(
+            String filterMode, List<String> filterValues, List<String> expectedResults) throws Exception {
+        verifyFetchedRelationships(filterMode, filterValues, expectedResults, EdgeDirection.IN,
+                                   TelicentGraphSchema.ARGUMENT_TYPE_FILTER, r -> r.getDomain().getUri());
+    }
+
+    @Test(dataProvider = "rangeFilters")
+    public void givenGraphWithTypes_whenFetchingRelationshipsWithRangeFilter_thenOnlyRelationshipsWithRelevantObjectsFetched(
+            String filterMode, List<String> filterValues, List<String> expectedResults) throws Exception {
+        // given
+        verifyFetchedRelationships(filterMode, filterValues, expectedResults, EdgeDirection.OUT,
+                                   TelicentGraphSchema.ARGUMENT_RANGE_FILTER, r -> r.getRange().getUri());
+    }
+
+    @Test(dataProvider = "domainFilters")
+    public void givenGraphWithTypes_whenFetchingRelationshipsWithDomainFilter_thenOnlyRelationshipsWithRelevantSubjectsFetched(
+            String filterMode, List<String> filterValues, List<String> expectedResults) throws Exception {
+        // given
+        verifyFetchedRelationships(filterMode, filterValues, expectedResults, EdgeDirection.IN,
+                                   TelicentGraphSchema.ARGUMENT_DOMAIN_FILTER, r -> r.getDomain().getUri());
+    }
+
+    @Test(dataProvider = "outboundTypeAndPredicateFilters")
+    public void givenGraphWithTypes_whenFetchingRelationshipsWithOutboundPredicateAndTypeFilter_thenOnlyRelationshipsWithRelevantPredicatesAndTypedObjectsFetched(
             String predicateFilterMode, List<String> predicateFilters, String typeFilterMode, List<String> typeFilters,
             List<String> expectedResults) throws Exception {
+        verifyDualFilterFetchedRelationships(predicateFilterMode, predicateFilters,
+                                             TelicentGraphSchema.ARGUMENT_PREDICATE_FILTER, typeFilterMode, typeFilters,
+                                             TelicentGraphSchema.ARGUMENT_TYPE_FILTER, expectedResults
+        );
+    }
+
+    private static void verifyDualFilterFetchedRelationships(String filter1Mode, List<String> filter1Values,
+                                                             String filter1Argument, String filter2Mode,
+                                                             List<String> filter2Values, String filter2Argument,
+                                                             List<String> expectedResults) throws Exception {
         // given
         RelationshipsFetcher fetcher = new RelationshipsFetcher(EdgeDirection.OUT);
         DatasetGraph dsg = DatasetGraphFactory.create();
@@ -244,16 +361,16 @@ public class TestRelationshipsFetcher extends AbstractFetcherTests {
         createTypedGraph(dsg, subject);
 
         DataFetchingEnvironment environment = prepareFetchingEnvironment(dsg, new TelicentGraphNode(subject, null),
-                                                                         Map.of(TelicentGraphSchema.ARGUMENT_PREDICATE_FILTER,
+                                                                         Map.of(filter1Argument,
                                                                                 Map.of(TelicentGraphSchema.ARGUMENT_MODE,
-                                                                                       predicateFilterMode,
+                                                                                       filter1Mode,
                                                                                        TelicentGraphSchema.ARGUMENT_VALUES,
-                                                                                       predicateFilters),
-                                                                                TelicentGraphSchema.ARGUMENT_TYPE_FILTER,
+                                                                                       filter1Values),
+                                                                                filter2Argument,
                                                                                 Map.of(TelicentGraphSchema.ARGUMENT_MODE,
-                                                                                       typeFilterMode,
+                                                                                       filter2Mode,
                                                                                        TelicentGraphSchema.ARGUMENT_VALUES,
-                                                                                       typeFilters)));
+                                                                                       filter2Values)));
 
         // When
         List<Relationship> actualList = fetcher.get(environment);
@@ -264,6 +381,16 @@ public class TestRelationshipsFetcher extends AbstractFetcherTests {
         for (String expected : expectedResults) {
             Assert.assertTrue(actualList.stream().anyMatch(r -> StringUtils.equals(r.getRange().getUri(), expected)));
         }
+    }
+
+    @Test(dataProvider = "predicateAndRangeFilters")
+    public void givenGraphWithTypes_whenFetchingRelationshipsWithPredicateAndRangeFilter_thenOnlyRelationshipsWithRelevantPredicatesAndObjectsFetched(
+            String predicateFilterMode, List<String> predicateFilters, String rangeFilterMode, List<String> rangeFilters,
+            List<String> expectedResults) throws Exception {
+        verifyDualFilterFetchedRelationships(predicateFilterMode, predicateFilters,
+                                             TelicentGraphSchema.ARGUMENT_PREDICATE_FILTER, rangeFilterMode, rangeFilters,
+                                             TelicentGraphSchema.ARGUMENT_RANGE_FILTER, expectedResults
+        );
     }
 
     @Test

--- a/telicent-graph-schema/src/test/java/io/telicent/jena/graphql/schemas/telicent/graph/models/inputs/TestIncludeAllFilter.java
+++ b/telicent-graph-schema/src/test/java/io/telicent/jena/graphql/schemas/telicent/graph/models/inputs/TestIncludeAllFilter.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright (C) Telicent Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.telicent.jena.graphql.schemas.telicent.graph.models.inputs;
+
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.sparql.core.DatasetGraphFactory;
+import org.apache.jena.sparql.core.Quad;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.stream.Stream;
+
+public class TestIncludeAllFilter {
+
+    @Test
+    public void givenIncludeAllFilter_whenInspectingConfig_thenAsExpected() {
+        // Given
+        Filter filter = IncludeAllFilter.INSTANCE;
+
+        // When and Then
+        Assert.assertEquals(filter.mode(), FilterMode.INCLUDE);
+        Assert.assertTrue(filter.values().isEmpty());
+    }
+
+    @Test
+    public void givenIncludeAllFilter_whenApplying_thenNoOp() {
+        // Given
+        Filter filter = IncludeAllFilter.INSTANCE;
+        Stream<Quad> stream = Stream.of(
+                new Quad(Quad.defaultGraphIRI, NodeFactory.createURI("subject"), NodeFactory.createURI("predicate"),
+                         NodeFactory.createLiteralString("object")));
+
+        // When
+        Stream<Quad> filtered = filter.filter(stream, DatasetGraphFactory.empty());
+
+        // Then
+        Assert.assertSame(stream, filtered);
+    }
+}

--- a/telicent-graph-schema/src/test/java/io/telicent/jena/graphql/schemas/telicent/graph/models/inputs/TestObjectFilter.java
+++ b/telicent-graph-schema/src/test/java/io/telicent/jena/graphql/schemas/telicent/graph/models/inputs/TestObjectFilter.java
@@ -12,20 +12,21 @@
  */
 package io.telicent.jena.graphql.schemas.telicent.graph.models.inputs;
 
-import graphql.org.antlr.v4.runtime.atn.SemanticContext;
 import org.apache.jena.atlas.lib.tuple.Tuple4;
 import org.apache.jena.graph.Node;
 import org.apache.jena.graph.NodeFactory;
 import org.apache.jena.sys.JenaSystem;
 import org.apache.jena.vocabulary.RDF;
-import org.apache.jena.vocabulary.RDFS;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import java.util.Collections;
 import java.util.List;
 
-public class TestPredicateFilter {
+public class TestObjectFilter {
+
+    private static final Node OBJECT_1 = NodeFactory.createURI("objectUri");
+    private static final Node OBJECT_2 = NodeFactory.createLiteralString("objectLiteral");
 
     static {
         JenaSystem.init();
@@ -34,28 +35,28 @@ public class TestPredicateFilter {
     @Test(expectedExceptions = NullPointerException.class, expectedExceptionsMessageRegExp = "mode.*null")
     public void givenNullFilterMode_whenCreatingFilter_thenNPE() {
         // Given, When and Then
-        new PredicateFilter(null, List.of(RDF.type.asNode()));
+        new ObjectFilter(null, List.of(RDF.type.asNode()));
     }
 
     @Test(expectedExceptions = NullPointerException.class, expectedExceptionsMessageRegExp = "Values.*null")
     public void givenNullValues_whenCreatingFilter_thenNPE() {
         // Given, When and Then
-        new PredicateFilter(FilterMode.INCLUDE, null);
+        new ObjectFilter(FilterMode.INCLUDE, null);
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "Values.*empty")
     public void givenNoValues_whenCreatingFilter_thenIllegalArgument() {
         // Given, When and Then
-        new PredicateFilter(FilterMode.INCLUDE, Collections.emptyList());
+        new ObjectFilter(FilterMode.INCLUDE, Collections.emptyList());
     }
 
     @Test
     public void givenValuesForInclusion_whenCreatingFilter_thenCorrect_andCanSupplyQuadPatterns() {
         // Given
-        List<Node> values = List.of(RDF.type.asNode(), RDFS.comment.asNode(), RDFS.label.asNode());
+        List<Node> values = List.of(OBJECT_1, OBJECT_2);
 
         // When
-        PredicateFilter filter = new PredicateFilter(FilterMode.INCLUDE, values);
+        QuadPatternFilter filter = new ObjectFilter(FilterMode.INCLUDE, values);
 
         // Then
         Assert.assertEquals(filter.mode(), FilterMode.INCLUDE);
@@ -64,16 +65,16 @@ public class TestPredicateFilter {
         // And
         List<Tuple4<Node>> quadPatterns = filter.getQuadPatterns(Node.ANY, Node.ANY, Node.ANY, Node.ANY);
         Assert.assertFalse(quadPatterns.isEmpty());
-        Assert.assertEquals(quadPatterns.size(), 3);
+        Assert.assertEquals(quadPatterns.size(), 2);
     }
 
     @Test
     public void givenValuesForExclusion_whenCreatingFilter_thenCorrect_andNoQuadPatterns() {
         // Given
-        List<Node> values = List.of(RDF.type.asNode(), RDFS.comment.asNode(), RDFS.label.asNode());
+        List<Node> values = List.of(OBJECT_1, OBJECT_2);
 
         // When
-        PredicateFilter filter = new PredicateFilter(FilterMode.EXCLUDE, values);
+        QuadPatternFilter filter = new ObjectFilter(FilterMode.EXCLUDE, values);
 
         // Then
         Assert.assertEquals(filter.mode(), FilterMode.EXCLUDE);
@@ -85,12 +86,12 @@ public class TestPredicateFilter {
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = ".*MUST be ANY")
-    public void givenFilter_whenCreatingQuadPatternsWithConcretePredicate_thenIllegalArgument() {
+    public void givenFilter_whenCreatingQuadPatternsWithConcreteSubject_thenIllegalArgument() {
         // Given
-        PredicateFilter filter = new PredicateFilter(FilterMode.INCLUDE, List.of(RDF.type.asNode()));
+        QuadPatternFilter filter = new ObjectFilter(FilterMode.INCLUDE, List.of(OBJECT_1));
 
         // When and Then
-        Node predicate = NodeFactory.createURI("predicate");
-        filter.getQuadPatterns(Node.ANY, Node.ANY, predicate, Node.ANY);;
+        Node object = NodeFactory.createURI("object");
+        filter.getQuadPatterns(Node.ANY, Node.ANY, Node.ANY, object);
     }
 }

--- a/telicent-graph-schema/src/test/java/io/telicent/jena/graphql/schemas/telicent/graph/models/inputs/TestPredicateFilter.java
+++ b/telicent-graph-schema/src/test/java/io/telicent/jena/graphql/schemas/telicent/graph/models/inputs/TestPredicateFilter.java
@@ -12,7 +12,6 @@
  */
 package io.telicent.jena.graphql.schemas.telicent.graph.models.inputs;
 
-import graphql.org.antlr.v4.runtime.atn.SemanticContext;
 import org.apache.jena.atlas.lib.tuple.Tuple4;
 import org.apache.jena.graph.Node;
 import org.apache.jena.graph.NodeFactory;

--- a/telicent-graph-schema/src/test/java/io/telicent/jena/graphql/schemas/telicent/graph/models/inputs/TestPredicateFilter.java
+++ b/telicent-graph-schema/src/test/java/io/telicent/jena/graphql/schemas/telicent/graph/models/inputs/TestPredicateFilter.java
@@ -1,0 +1,84 @@
+/**
+ * Copyright (C) Telicent Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.telicent.jena.graphql.schemas.telicent.graph.models.inputs;
+
+import org.apache.jena.atlas.lib.tuple.Tuple4;
+import org.apache.jena.graph.Node;
+import org.apache.jena.sys.JenaSystem;
+import org.apache.jena.vocabulary.RDF;
+import org.apache.jena.vocabulary.RDFS;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+public class TestPredicateFilter {
+
+    static {
+        JenaSystem.init();
+    }
+
+    @Test(expectedExceptions = NullPointerException.class, expectedExceptionsMessageRegExp = "mode.*null")
+    public void givenNullFilterMode_whenCreatingFilter_thenNPE() {
+        // Given, When and Then
+        new PredicateFilter(null, List.of(RDF.type.asNode()));
+    }
+
+    @Test(expectedExceptions = NullPointerException.class, expectedExceptionsMessageRegExp = "Values.*null")
+    public void givenNullValues_whenCreatingFilter_thenNPE() {
+        // Given, When and Then
+        new PredicateFilter(FilterMode.INCLUDE, null);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "Values.*empty")
+    public void givenNoValues_whenCreatingFilter_thenIllegalArgument() {
+        // Given, When and Then
+        new PredicateFilter(FilterMode.INCLUDE, Collections.emptyList());
+    }
+
+    @Test
+    public void givenValuesForInclusion_whenCreatingFilter_thenCorrect_andCanSupplyQuadPatterns() {
+        // Given
+        List<Node> values = List.of(RDF.type.asNode(), RDFS.comment.asNode(), RDFS.label.asNode());
+
+        // When
+        PredicateFilter filter = new PredicateFilter(FilterMode.INCLUDE, values);
+
+        // Then
+        Assert.assertEquals(filter.mode(), FilterMode.INCLUDE);
+        Assert.assertTrue(filter.values().containsAll(values));
+
+        // And
+        List<Tuple4<Node>> quadPatterns = filter.getQuadPatterns(Node.ANY, Node.ANY, Node.ANY, Node.ANY);
+        Assert.assertFalse(quadPatterns.isEmpty());
+        Assert.assertEquals(quadPatterns.size(), 3);
+    }
+
+    @Test
+    public void givenValuesForExclusion_whenCreatingFilter_thenCorrect_andNoQuadPatterns() {
+        // Given
+        List<Node> values = List.of(RDF.type.asNode(), RDFS.comment.asNode(), RDFS.label.asNode());
+
+        // When
+        PredicateFilter filter = new PredicateFilter(FilterMode.EXCLUDE, values);
+
+        // Then
+        Assert.assertEquals(filter.mode(), FilterMode.EXCLUDE);
+        Assert.assertTrue(filter.values().containsAll(values));
+
+        // And
+        List<Tuple4<Node>> quadPatterns = filter.getQuadPatterns(Node.ANY, Node.ANY, Node.ANY, Node.ANY);
+        Assert.assertTrue(quadPatterns.isEmpty());
+    }
+}

--- a/telicent-graph-schema/src/test/java/io/telicent/jena/graphql/schemas/telicent/graph/models/inputs/TestQuadPatternFilter.java
+++ b/telicent-graph-schema/src/test/java/io/telicent/jena/graphql/schemas/telicent/graph/models/inputs/TestQuadPatternFilter.java
@@ -110,10 +110,25 @@ public class TestQuadPatternFilter {
                 };
     }
 
-    @Test(dataProvider = "singlePattern", expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = ".*concrete values.*")
-    public void givenSinglePattern_whenCombiningWithItself_thenIllegalArgumentDueToConflict(
+    @Test(dataProvider = "singlePattern")
+    public void givenSinglePattern_whenCombiningWithItself_thenOk(
             List<Tuple4<Node>> pattern) {
-        // Given, When and Then
-        QuadPatternFilter.combinePatterns(pattern, pattern);
+        // Given and When
+        List<Tuple4<Node>> combined = QuadPatternFilter.combinePatterns(pattern, pattern);
+
+        // Then
+        Assert.assertEquals(combined.size(), pattern.size());
+    }
+
+    @Test(dataProvider = "singlePattern", expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = ".*conflicting concrete values.*")
+    public void givenSinglePattern_whenCombiningWithConcretePattern_thenConflict(
+            List<Tuple4<Node>> pattern) {
+        // Given
+        List<Tuple4<Node>> conflicting =
+                List.of(TupleFactory.create4(NodeFactory.createURI("g"), NodeFactory.createURI("s"),
+                                             NodeFactory.createURI("p"), NodeFactory.createURI("o")));
+
+        // When and Then
+        QuadPatternFilter.combinePatterns(pattern, conflicting);
     }
 }

--- a/telicent-graph-schema/src/test/java/io/telicent/jena/graphql/schemas/telicent/graph/models/inputs/TestQuadPatternFilter.java
+++ b/telicent-graph-schema/src/test/java/io/telicent/jena/graphql/schemas/telicent/graph/models/inputs/TestQuadPatternFilter.java
@@ -1,0 +1,119 @@
+/**
+ * Copyright (C) Telicent Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.telicent.jena.graphql.schemas.telicent.graph.models.inputs;
+
+import org.apache.jena.atlas.lib.tuple.Tuple4;
+import org.apache.jena.atlas.lib.tuple.TupleFactory;
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.sys.JenaSystem;
+import org.apache.jena.vocabulary.RDF;
+import org.apache.jena.vocabulary.RDFS;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class TestQuadPatternFilter {
+
+    static {
+        JenaSystem.init();
+    }
+
+    @DataProvider(name = "patterns")
+    private Object[][] patterns() {
+        // Concrete node values
+        Node s1 = NodeFactory.createURI("https://example.com/s1");
+        Node s2 = NodeFactory.createURI("https://example.com/s2");
+        Node rdfType = RDF.type.asNode();
+        Node rdfsLabel = RDFS.label.asNode();
+        Node rdfsComment = RDFS.comment.asNode();
+        List<Node> predicates = generatePredicates();
+
+        // Filter patterns
+        List<Tuple4<Node>> rdfTypePredicate = List.of(TupleFactory.create4(Node.ANY, Node.ANY, rdfType, Node.ANY));
+        List<Tuple4<Node>> rdfsPredicates = List.of(TupleFactory.create4(Node.ANY, Node.ANY, rdfsLabel, Node.ANY),
+                                                    TupleFactory.create4(Node.ANY, Node.ANY, rdfsComment, Node.ANY));
+        List<Tuple4<Node>> manyPredicates =
+                new PredicateFilter(FilterMode.INCLUDE, predicates).getQuadPatterns(Node.ANY, Node.ANY, Node.ANY,
+                                                                                    Node.ANY);
+        List<Tuple4<Node>> subject1Or2 = List.of(TupleFactory.create4(Node.ANY, s1, Node.ANY, Node.ANY),
+                                                 TupleFactory.create4(Node.ANY, s2, Node.ANY, Node.ANY));
+
+        // Expected Combined Patterns
+        List<Tuple4<Node>> subjectsPlusRdfType = List.of(TupleFactory.create4(Node.ANY, s1, rdfType, Node.ANY),
+                                                         TupleFactory.create4(Node.ANY, s2, rdfType, Node.ANY));
+        List<Tuple4<Node>> subjectsPlusRdfsPredicates = List.of(TupleFactory.create4(Node.ANY, s1, rdfsLabel, Node.ANY),
+                                                                TupleFactory.create4(Node.ANY, s1, rdfsComment,
+                                                                                     Node.ANY),
+                                                                TupleFactory.create4(Node.ANY, s2, rdfsLabel, Node.ANY),
+                                                                TupleFactory.create4(Node.ANY, s2, rdfsComment,
+                                                                                     Node.ANY));
+        List<Tuple4<Node>> subjectsPlusManyPredicates = new ArrayList<>();
+        populateCombinedPatterns(s1, predicates, subjectsPlusManyPredicates);
+        populateCombinedPatterns(s2, predicates, subjectsPlusManyPredicates);
+
+        return new Object[][] {
+                { rdfTypePredicate, subject1Or2, subjectsPlusRdfType },
+                { subject1Or2, rdfTypePredicate, subjectsPlusRdfType },
+                { rdfsPredicates, subject1Or2, subjectsPlusRdfsPredicates },
+                { subject1Or2, rdfsPredicates, subjectsPlusRdfsPredicates },
+                { manyPredicates, subject1Or2, subjectsPlusManyPredicates }
+        };
+    }
+
+    private void populateCombinedPatterns(Node subject, List<Node> predicates,
+                                          List<Tuple4<Node>> combined) {
+        for (Node predicate : predicates) {
+            combined.add(TupleFactory.create4(Node.ANY, subject, predicate, Node.ANY));
+        }
+    }
+
+    private List<Node> generatePredicates() {
+        List<Node> predicates = new ArrayList<>();
+        for (int i = 1; i <= 100; i++) {
+            predicates.add(NodeFactory.createURI("https://example.com/predicate" + i));
+        }
+        return predicates;
+    }
+
+    @Test(dataProvider = "patterns")
+    public void givenPatterns_whenCombining_thenCorrectCombinations(List<Tuple4<Node>> left, List<Tuple4<Node>> right,
+                                                                    List<Tuple4<Node>> expected) {
+        // Given and When
+        List<Tuple4<Node>> combined = QuadPatternFilter.combinePatterns(left, right);
+
+        // Then
+        Assert.assertEquals(combined.size(), expected.size());
+        Assert.assertTrue(combined.containsAll(expected));
+    }
+
+    @DataProvider(name = "singlePattern")
+    private Object[][] singlePattern() {
+        return new Object[][] {
+                { List.of(TupleFactory.create4(NodeFactory.createURI("g1"), Node.ANY, Node.ANY, Node.ANY)) },
+                { List.of(TupleFactory.create4(Node.ANY, NodeFactory.createURI("s1"), Node.ANY, Node.ANY)) },
+                { List.of(TupleFactory.create4(Node.ANY, Node.ANY, NodeFactory.createURI("p1"), Node.ANY)) },
+                { List.of(TupleFactory.create4(Node.ANY, Node.ANY, Node.ANY, NodeFactory.createURI("o1"))) },
+                };
+    }
+
+    @Test(dataProvider = "singlePattern", expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = ".*concrete values.*")
+    public void givenSinglePattern_whenCombiningWithItself_thenIllegalArgumentDueToConflict(
+            List<Tuple4<Node>> pattern) {
+        // Given, When and Then
+        QuadPatternFilter.combinePatterns(pattern, pattern);
+    }
+}

--- a/telicent-graph-schema/src/test/java/io/telicent/jena/graphql/schemas/telicent/graph/models/inputs/TestSubjectFilter.java
+++ b/telicent-graph-schema/src/test/java/io/telicent/jena/graphql/schemas/telicent/graph/models/inputs/TestSubjectFilter.java
@@ -17,7 +17,6 @@ import org.apache.jena.graph.Node;
 import org.apache.jena.graph.NodeFactory;
 import org.apache.jena.sys.JenaSystem;
 import org.apache.jena.vocabulary.RDF;
-import org.apache.jena.vocabulary.RDFS;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 

--- a/telicent-graph-schema/src/test/java/io/telicent/jena/graphql/schemas/telicent/graph/models/inputs/TestSubjectFilter.java
+++ b/telicent-graph-schema/src/test/java/io/telicent/jena/graphql/schemas/telicent/graph/models/inputs/TestSubjectFilter.java
@@ -12,7 +12,6 @@
  */
 package io.telicent.jena.graphql.schemas.telicent.graph.models.inputs;
 
-import graphql.org.antlr.v4.runtime.atn.SemanticContext;
 import org.apache.jena.atlas.lib.tuple.Tuple4;
 import org.apache.jena.graph.Node;
 import org.apache.jena.graph.NodeFactory;
@@ -25,7 +24,10 @@ import org.testng.annotations.Test;
 import java.util.Collections;
 import java.util.List;
 
-public class TestPredicateFilter {
+public class TestSubjectFilter {
+
+    private static final Node SUBJECT_1 = NodeFactory.createURI("subject1");
+    private static final Node SUBJECT_2 = NodeFactory.createURI("subject2");
 
     static {
         JenaSystem.init();
@@ -34,28 +36,28 @@ public class TestPredicateFilter {
     @Test(expectedExceptions = NullPointerException.class, expectedExceptionsMessageRegExp = "mode.*null")
     public void givenNullFilterMode_whenCreatingFilter_thenNPE() {
         // Given, When and Then
-        new PredicateFilter(null, List.of(RDF.type.asNode()));
+        new SubjectFilter(null, List.of(RDF.type.asNode()));
     }
 
     @Test(expectedExceptions = NullPointerException.class, expectedExceptionsMessageRegExp = "Values.*null")
     public void givenNullValues_whenCreatingFilter_thenNPE() {
         // Given, When and Then
-        new PredicateFilter(FilterMode.INCLUDE, null);
+        new SubjectFilter(FilterMode.INCLUDE, null);
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "Values.*empty")
     public void givenNoValues_whenCreatingFilter_thenIllegalArgument() {
         // Given, When and Then
-        new PredicateFilter(FilterMode.INCLUDE, Collections.emptyList());
+        new SubjectFilter(FilterMode.INCLUDE, Collections.emptyList());
     }
 
     @Test
     public void givenValuesForInclusion_whenCreatingFilter_thenCorrect_andCanSupplyQuadPatterns() {
         // Given
-        List<Node> values = List.of(RDF.type.asNode(), RDFS.comment.asNode(), RDFS.label.asNode());
+        List<Node> values = List.of(SUBJECT_1, SUBJECT_2);
 
         // When
-        PredicateFilter filter = new PredicateFilter(FilterMode.INCLUDE, values);
+        QuadPatternFilter filter = new SubjectFilter(FilterMode.INCLUDE, values);
 
         // Then
         Assert.assertEquals(filter.mode(), FilterMode.INCLUDE);
@@ -64,16 +66,16 @@ public class TestPredicateFilter {
         // And
         List<Tuple4<Node>> quadPatterns = filter.getQuadPatterns(Node.ANY, Node.ANY, Node.ANY, Node.ANY);
         Assert.assertFalse(quadPatterns.isEmpty());
-        Assert.assertEquals(quadPatterns.size(), 3);
+        Assert.assertEquals(quadPatterns.size(), 2);
     }
 
     @Test
     public void givenValuesForExclusion_whenCreatingFilter_thenCorrect_andNoQuadPatterns() {
         // Given
-        List<Node> values = List.of(RDF.type.asNode(), RDFS.comment.asNode(), RDFS.label.asNode());
+        List<Node> values = List.of(SUBJECT_1, SUBJECT_2);
 
         // When
-        PredicateFilter filter = new PredicateFilter(FilterMode.EXCLUDE, values);
+        QuadPatternFilter filter = new SubjectFilter(FilterMode.EXCLUDE, values);
 
         // Then
         Assert.assertEquals(filter.mode(), FilterMode.EXCLUDE);
@@ -85,12 +87,12 @@ public class TestPredicateFilter {
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = ".*MUST be ANY")
-    public void givenFilter_whenCreatingQuadPatternsWithConcretePredicate_thenIllegalArgument() {
+    public void givenFilter_whenCreatingQuadPatternsWithConcreteSubject_thenIllegalArgument() {
         // Given
-        PredicateFilter filter = new PredicateFilter(FilterMode.INCLUDE, List.of(RDF.type.asNode()));
+        QuadPatternFilter filter = new SubjectFilter(FilterMode.INCLUDE, List.of(SUBJECT_1));
 
         // When and Then
-        Node predicate = NodeFactory.createURI("predicate");
-        filter.getQuadPatterns(Node.ANY, Node.ANY, predicate, Node.ANY);;
+        Node subject = NodeFactory.createURI("subject");
+        filter.getQuadPatterns(Node.ANY, subject, Node.ANY, Node.ANY);;
     }
 }

--- a/telicent-graph-schema/src/test/resources/queries/telicent/graph/single-node-with-filters.graphql
+++ b/telicent-graph-schema/src/test/resources/queries/telicent/graph/single-node-with-filters.graphql
@@ -1,10 +1,10 @@
-query($predFilter: UriFilter, $typeFilter: UriFilter) {
+query($predFilter: UriFilter, $typeFilter: UriFilter, $nodeFilter: UriFilter) {
     node(uri: "https://starwars.com#person_Obi-WanKenobi") {
         id
         uri
         shortUri
         # We can filter relationships by both predicate and/or type
-        inRels(predicateFilter: $predFilter, typeFilter: $typeFilter) {
+        inRels(predicateFilter: $predFilter, typeFilter: $typeFilter, nodeFilter: $nodeFilter) {
             id
             domain {
                 uri
@@ -12,7 +12,7 @@ query($predFilter: UriFilter, $typeFilter: UriFilter) {
             domain_id
             predicate
         }
-        outRels(predicateFilter: $predFilter, typeFilter: $typeFilter) {
+        outRels(predicateFilter: $predFilter, typeFilter: $typeFilter, nodeFilter: $nodeFilter) {
             id
             predicate
             range {
@@ -23,8 +23,8 @@ query($predFilter: UriFilter, $typeFilter: UriFilter) {
         relCounts {
             # NB - If we also supply our filters to the relCounts sub-fields then those counts will reflect our filter
             #      conditions, if we don't do this then they still reflect total counts
-            inRels(predicateFilter: $predFilter, typeFilter: $typeFilter)
-            outRels(predicateFilter: $predFilter, typeFilter: $typeFilter)
+            inRels(predicateFilter: $predFilter, typeFilter: $typeFilter, nodeFilter: $nodeFilter)
+            outRels(predicateFilter: $predFilter, typeFilter: $typeFilter, nodeFilter: $nodeFilter)
         }
         relFacets {
             inRels {


### PR DESCRIPTION
Adds machinery for supporting new `nodeFilter` argument on `inRels`/`outRels`, this allows the caller to limit the `inRels`/`outRls` to those that go from/to specific nodes in the graph.

Also refactored the internal implementation of `INCLUDE` filters so we optimise our database scans where possible, and cleaned up some deprecated API usage, unused imports etc.

# Outstanding Work

- [x] Add test coverage
- [x] Updated `CHANGELOG`
- [x] Updates Documentation