### PR TITLE
[CORE-1234] Call tailored Search endpoint

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
         <!-- CVE-2025-48976 -->
         <dependency.commons-fileupload>2.0.0-M5</dependency.commons-fileupload>
         <!-- CVE-2026-1605 -->
-        <dependency.jetty>12.1.6</dependency.jetty>
+        <dependency.jetty>12.1.7</dependency.jetty>
 
         <!-- Build configuration -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/fetchers/telicent/graph/AbstractSearchFetcher.java
+++ b/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/fetchers/telicent/graph/AbstractSearchFetcher.java
@@ -58,6 +58,11 @@ public abstract class AbstractSearchFetcher<T> implements DataFetcher<T> {
      * The default Search API URL used if none was supplied
      */
     public static final String DEFAULT_SEARCH_API_URL = "http://localhost:8181";
+    /**
+     * The environment variable/system property used to configure whether graph searches use the tailored Search API
+     * endpoint by default.
+     */
+    public static final String ENV_SEARCH_API_USE_FAST_GRAPH_SEARCH = "SEARCH_API_USE_FAST_GRAPH_SEARCH";
     private static final Logger LOGGER = LoggerFactory.getLogger(AbstractSearchFetcher.class);
     private static final ObjectMapper JSON = new ObjectMapper();
     private final HttpClient client = HttpClient.newBuilder().build();
@@ -80,16 +85,16 @@ public abstract class AbstractSearchFetcher<T> implements DataFetcher<T> {
      */
     public static URI buildSearchApiRequestUri(String searchApiUrl, String searchTerm,
                                                DataFetchingEnvironment environment) {
+        return buildSearchApiRequestUri(searchApiUrl, searchTerm, environment, useFastGraphSearchByDefault());
+    }
+
+    static URI buildSearchApiRequestUri(String searchApiUrl, String searchTerm, DataFetchingEnvironment environment,
+                                        boolean useFastGraphSearch) {
         StringBuilder builder = new StringBuilder();
         builder.append(searchApiUrl)
-               .append("/documents?query=")
+               .append(useFastGraphSearch ? "/documents/graph-search?query=" : "/documents?query=")
                .append(URLEncoder.encode(searchTerm, StandardCharsets.UTF_8));
 
-        // Add optional parameters
-        SearchType searchType = environment.getArgument(TelicentGraphSchema.ARGUMENT_SEARCH_TYPE);
-        if (searchType != null) {
-            builder.append("&type=").append(searchType.name().toLowerCase(Locale.ROOT));
-        }
         Integer limit = environment.getArgument(TelicentGraphSchema.ARGUMENT_LIMIT);
         if (limit != null && limit > 0) {
             builder.append("&limit=").append(limit);
@@ -98,13 +103,27 @@ public abstract class AbstractSearchFetcher<T> implements DataFetcher<T> {
         if (offset != null && offset >= 1) {
             builder.append("&offset=").append(offset);
         }
-        String typeFilter = environment.getArgument(TelicentGraphSchema.ARGUMENT_TYPE_FILTER);
-        if (StringUtils.isNotBlank(typeFilter)) {
-            builder.append("&type-filter=")
-                   .append(Base64.encodeBase64URLSafeString(typeFilter.getBytes(StandardCharsets.UTF_8)))
-                   .append("&is-type-filter-base64=true");
+        if (!useFastGraphSearch) {
+            SearchType searchType = environment.getArgument(TelicentGraphSchema.ARGUMENT_SEARCH_TYPE);
+            if (searchType != null) {
+                builder.append("&type=").append(searchType.name().toLowerCase(Locale.ROOT));
+            }
+            String typeFilter = environment.getArgument(TelicentGraphSchema.ARGUMENT_TYPE_FILTER);
+            if (StringUtils.isNotBlank(typeFilter)) {
+                builder.append("&type-filter=")
+                       .append(Base64.encodeBase64URLSafeString(typeFilter.getBytes(StandardCharsets.UTF_8)))
+                       .append("&is-type-filter-base64=true");
+            }
         }
         return URI.create(builder.toString());
+    }
+
+    static boolean useFastGraphSearchByDefault() {
+        String envValue = System.getenv(ENV_SEARCH_API_USE_FAST_GRAPH_SEARCH);
+        if (StringUtils.isNotBlank(envValue)) {
+            return Boolean.parseBoolean(envValue);
+        }
+        return Boolean.parseBoolean(System.getProperty(ENV_SEARCH_API_USE_FAST_GRAPH_SEARCH, Boolean.TRUE.toString()));
     }
 
     private static String findSearchApiUrl() {

--- a/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/fetchers/telicent/graph/AbstractSearchFetcher.java
+++ b/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/fetchers/telicent/graph/AbstractSearchFetcher.java
@@ -92,7 +92,7 @@ public abstract class AbstractSearchFetcher<T> implements DataFetcher<T> {
                                         boolean useFastGraphSearch) {
         StringBuilder builder = new StringBuilder();
         builder.append(searchApiUrl)
-               .append(useFastGraphSearch ? "/documents/graph-search?query=" : "/documents?query=")
+               .append(useFastGraphSearch ? "/documents/uri-search?query=" : "/documents?query=")
                .append(URLEncoder.encode(searchTerm, StandardCharsets.UTF_8));
 
         Integer limit = environment.getArgument(TelicentGraphSchema.ARGUMENT_LIMIT);

--- a/telicent-graph-schema/src/test/java/io/telicent/jena/graphql/execution/telicent/graph/TestTelicentGraphSearchExecution.java
+++ b/telicent-graph-schema/src/test/java/io/telicent/jena/graphql/execution/telicent/graph/TestTelicentGraphSearchExecution.java
@@ -54,7 +54,7 @@ public class TestTelicentGraphSearchExecution extends AbstractExecutionTests {
         Map<String, ?> pagedData = Map.of("limit", "10", "offset", "20", "results", List.of(Map.of("document",
                                                                                                    Map.of("uri",
                                                                                                           TestTelicentGraphExecution.OBI_WAN_KENOBI))));
-        WIRE_MOCK_SERVER.stubFor(get(urlEqualTo("/documents/graph-search?query=test&limit=10&offset=20")).willReturn(
+        WIRE_MOCK_SERVER.stubFor(get(urlEqualTo("/documents/uri-search?query=test&limit=10&offset=20")).willReturn(
                 ok().withBody(MAPPER.writeValueAsString(pagedData))));
     }
 

--- a/telicent-graph-schema/src/test/java/io/telicent/jena/graphql/execution/telicent/graph/TestTelicentGraphSearchExecution.java
+++ b/telicent-graph-schema/src/test/java/io/telicent/jena/graphql/execution/telicent/graph/TestTelicentGraphSearchExecution.java
@@ -54,7 +54,7 @@ public class TestTelicentGraphSearchExecution extends AbstractExecutionTests {
         Map<String, ?> pagedData = Map.of("limit", "10", "offset", "20", "results", List.of(Map.of("document",
                                                                                                    Map.of("uri",
                                                                                                           TestTelicentGraphExecution.OBI_WAN_KENOBI))));
-        WIRE_MOCK_SERVER.stubFor(get(urlEqualTo("/documents?query=test&limit=10&offset=20")).willReturn(
+        WIRE_MOCK_SERVER.stubFor(get(urlEqualTo("/documents/graph-search?query=test&limit=10&offset=20")).willReturn(
                 ok().withBody(MAPPER.writeValueAsString(pagedData))));
     }
 

--- a/telicent-graph-schema/src/test/java/io/telicent/jena/graphql/fetchers/telicent/graph/TestAbstractSearchFetcher.java
+++ b/telicent-graph-schema/src/test/java/io/telicent/jena/graphql/fetchers/telicent/graph/TestAbstractSearchFetcher.java
@@ -50,6 +50,24 @@ public class TestAbstractSearchFetcher {
                                                                environment);
 
         // Then
+        Assert.assertEquals(searchUrl.getPath(), "/documents/graph-search");
+        Assert.assertEquals(searchUrl.getQuery(), "query=test");
+    }
+
+    @Test
+    public void givenMinimalArguments_whenFormingLegacySearchUrl_thenLegacyUrl() {
+        TelicentExecutionContext context = new TelicentExecutionContext(dsg, "");
+        DataFetchingEnvironment environment = DataFetchingEnvironmentImpl.newDataFetchingEnvironment()
+                                                                         .localContext(context)
+                                                                         .arguments(
+                                                                                 Map.of(TelicentGraphSchema.ARGUMENT_SEARCH_TERM,
+                                                                                        "test"))
+                                                                         .build();
+
+        URI searchUrl =
+                AbstractSearchFetcher.buildSearchApiRequestUri(AbstractSearchFetcher.DEFAULT_SEARCH_API_URL, "test",
+                                                               environment, false);
+
         Assert.assertEquals(searchUrl.getPath(), "/documents");
         Assert.assertEquals(searchUrl.getQuery(), "query=test");
     }
@@ -57,7 +75,6 @@ public class TestAbstractSearchFetcher {
     @DataProvider(name = "searchArguments")
     public Object[][] searchArguments() {
         return new Object[][] {
-                { Map.of(TelicentGraphSchema.ARGUMENT_SEARCH_TYPE, SearchType.TERM), Map.of("type", "term") },
                 {
                         Map.of(TelicentGraphSchema.ARGUMENT_LIMIT, 10, TelicentGraphSchema.ARGUMENT_OFFSET, 100),
                         Map.of(TelicentGraphSchema.ARGUMENT_LIMIT, "1", TelicentGraphSchema.ARGUMENT_OFFSET, "100")
@@ -65,12 +82,6 @@ public class TestAbstractSearchFetcher {
                 {
                         Map.of(TelicentGraphSchema.ARGUMENT_LIMIT, 100),
                         Map.of(TelicentGraphSchema.ARGUMENT_LIMIT, "100")
-                },
-                {
-                        Map.of(TelicentGraphSchema.ARGUMENT_TYPE_FILTER, "Person"),
-                        Map.of("type-filter",
-                               Base64.encodeBase64URLSafeString("Person".getBytes(StandardCharsets.UTF_8)),
-                               "is-type-filter-base64", "true")
                 }
         };
     }
@@ -90,12 +101,64 @@ public class TestAbstractSearchFetcher {
                                                                        environment);
 
         // Then
-        Assert.assertEquals(searchUrl.getPath(), "/api/search/documents");
+        Assert.assertEquals(searchUrl.getPath(), "/api/search/documents/graph-search");
         Assert.assertTrue(Strings.CS.contains(searchUrl.getQuery(), "query=test"));
         for (Map.Entry<String, String> entry : expectedQuerystringParameters.entrySet()) {
             Assert.assertTrue(Strings.CS.contains(searchUrl.getQuery(),
                                                    String.format("&%s=%s", entry.getKey(), entry.getValue())),
                               "Expected querystring parameter " + entry.getKey() + " was not present in generated URL");
         }
+    }
+
+    @Test
+    public void givenUnusedFastArguments_whenFormingSearchUrl_thenIgnoredInFastUrl() {
+        TelicentExecutionContext context = new TelicentExecutionContext(dsg, "");
+        DataFetchingEnvironment environment = DataFetchingEnvironmentImpl.newDataFetchingEnvironment()
+                                                                         .localContext(context)
+                                                                         .arguments(Map.of(
+                                                                                 TelicentGraphSchema.ARGUMENT_SEARCH_TERM,
+                                                                                 "test",
+                                                                                 TelicentGraphSchema.ARGUMENT_SEARCH_TYPE,
+                                                                                 SearchType.TERM,
+                                                                                 TelicentGraphSchema.ARGUMENT_TYPE_FILTER,
+                                                                                 "Person"))
+                                                                         .build();
+
+        URI searchUrl = AbstractSearchFetcher.buildSearchApiRequestUri("https://some-deployment/api/search", "test",
+                                                                       environment);
+
+        Assert.assertEquals(searchUrl.getPath(), "/api/search/documents/graph-search");
+        Assert.assertEquals(searchUrl.getQuery(), "query=test");
+    }
+
+    @Test
+    public void givenLegacyOnlyArguments_whenFormingLegacySearchUrl_thenReflectedInUrl() {
+        TelicentExecutionContext context = new TelicentExecutionContext(dsg, "");
+        DataFetchingEnvironment environment = DataFetchingEnvironmentImpl.newDataFetchingEnvironment()
+                                                                         .localContext(context)
+                                                                         .arguments(Map.of(
+                                                                                 TelicentGraphSchema.ARGUMENT_SEARCH_TERM,
+                                                                                 "test",
+                                                                                 TelicentGraphSchema.ARGUMENT_SEARCH_TYPE,
+                                                                                 SearchType.TERM,
+                                                                                 TelicentGraphSchema.ARGUMENT_TYPE_FILTER,
+                                                                                 "Person"))
+                                                                         .build();
+
+        URI searchUrl = AbstractSearchFetcher.buildSearchApiRequestUri("https://some-deployment/api/search", "test",
+                                                                       environment, false);
+
+        Assert.assertEquals(searchUrl.getPath(), "/api/search/documents");
+        Assert.assertTrue(Strings.CS.contains(searchUrl.getQuery(), "query=test"));
+        Assert.assertTrue(Strings.CS.contains(searchUrl.getQuery(), "&type=term"));
+        Assert.assertTrue(Strings.CS.contains(searchUrl.getQuery(),
+                                              "&type-filter=" + Base64.encodeBase64URLSafeString(
+                                                      "Person".getBytes(StandardCharsets.UTF_8))));
+        Assert.assertTrue(Strings.CS.contains(searchUrl.getQuery(), "&is-type-filter-base64=true"));
+    }
+
+    @Test
+    public void givenNoOverride_whenCheckingFastGraphSearchFlag_thenDefaultsTrue() {
+        Assert.assertTrue(AbstractSearchFetcher.useFastGraphSearchByDefault());
     }
 }

--- a/telicent-graph-schema/src/test/java/io/telicent/jena/graphql/fetchers/telicent/graph/TestAbstractSearchFetcher.java
+++ b/telicent-graph-schema/src/test/java/io/telicent/jena/graphql/fetchers/telicent/graph/TestAbstractSearchFetcher.java
@@ -50,7 +50,7 @@ public class TestAbstractSearchFetcher {
                                                                environment);
 
         // Then
-        Assert.assertEquals(searchUrl.getPath(), "/documents/graph-search");
+        Assert.assertEquals(searchUrl.getPath(), "/documents/uri-search");
         Assert.assertEquals(searchUrl.getQuery(), "query=test");
     }
 
@@ -101,7 +101,7 @@ public class TestAbstractSearchFetcher {
                                                                        environment);
 
         // Then
-        Assert.assertEquals(searchUrl.getPath(), "/api/search/documents/graph-search");
+        Assert.assertEquals(searchUrl.getPath(), "/api/search/documents/uri-search");
         Assert.assertTrue(Strings.CS.contains(searchUrl.getQuery(), "query=test"));
         for (Map.Entry<String, String> entry : expectedQuerystringParameters.entrySet()) {
             Assert.assertTrue(Strings.CS.contains(searchUrl.getQuery(),
@@ -127,7 +127,7 @@ public class TestAbstractSearchFetcher {
         URI searchUrl = AbstractSearchFetcher.buildSearchApiRequestUri("https://some-deployment/api/search", "test",
                                                                        environment);
 
-        Assert.assertEquals(searchUrl.getPath(), "/api/search/documents/graph-search");
+        Assert.assertEquals(searchUrl.getPath(), "/api/search/documents/uri-search");
         Assert.assertEquals(searchUrl.getQuery(), "query=test");
     }
 

--- a/telicent-graph-schema/src/test/java/io/telicent/jena/graphql/fetchers/telicent/graph/TestStartingSearchFetcher.java
+++ b/telicent-graph-schema/src/test/java/io/telicent/jena/graphql/fetchers/telicent/graph/TestStartingSearchFetcher.java
@@ -84,7 +84,7 @@ public class TestStartingSearchFetcher {
     @Test(expectedExceptions = RuntimeException.class)
     public void givenBadSearchResponse_whenUsingSearchFetcher_thenErrorIsThrown() {
         // given
-        WIRE_MOCK_SERVER.stubFor(get(urlEqualTo("/documents?query=test")).willReturn(notFound()));
+        WIRE_MOCK_SERVER.stubFor(get(urlEqualTo("/documents/graph-search?query=test")).willReturn(notFound()));
 
         StartingSearchFetcher fetcher = new StartingSearchFetcher();
         DatasetGraph dsg = DatasetGraphFactory.create();
@@ -108,7 +108,7 @@ public class TestStartingSearchFetcher {
     public void givenEmptySearchResponse_whenUsingSearchFetcher_thenSuccess() {
         // given
         System.setProperty("SEARCH_API_URL", "http://localhost:8181/");
-        WIRE_MOCK_SERVER.stubFor(get(urlEqualTo("/documents?query=test")).willReturn(ok().withBody("{}")));
+        WIRE_MOCK_SERVER.stubFor(get(urlEqualTo("/documents/graph-search?query=test")).willReturn(ok().withBody("{}")));
 
         StartingSearchFetcher fetcher = new StartingSearchFetcher();
         DatasetGraph dsg = DatasetGraphFactory.create();
@@ -128,7 +128,7 @@ public class TestStartingSearchFetcher {
         // then
         Assert.assertNotNull(actualList);
         Assert.assertTrue(actualList.isEmpty());
-        WIRE_MOCK_SERVER.verify(getRequestedFor(urlEqualTo("/documents?query=test")));
+        WIRE_MOCK_SERVER.verify(getRequestedFor(urlEqualTo("/documents/graph-search?query=test")));
     }
 
     @Test
@@ -139,7 +139,7 @@ public class TestStartingSearchFetcher {
                                                                                         emptyMap(), Map.of("document",
                                                                                                            Map.of("something",
                                                                                                                   "else"))));
-        WIRE_MOCK_SERVER.stubFor(get(urlEqualTo("/documents?query=test")).willReturn(
+        WIRE_MOCK_SERVER.stubFor(get(urlEqualTo("/documents/graph-search?query=test")).willReturn(
                 ok().withBody(MAPPER.writeValueAsString(returnedData))));
 
         StartingSearchFetcher fetcher = new StartingSearchFetcher();
@@ -157,7 +157,7 @@ public class TestStartingSearchFetcher {
         // then
         Assert.assertNotNull(actualList);
         Assert.assertFalse(actualList.isEmpty());
-        WIRE_MOCK_SERVER.verify(getRequestedFor(urlEqualTo("/documents?query=test")));
+        WIRE_MOCK_SERVER.verify(getRequestedFor(urlEqualTo("/documents/graph-search?query=test")));
     }
 
     private static List<Map<?, ?>> createPagedResultDocuments() {
@@ -192,7 +192,7 @@ public class TestStartingSearchFetcher {
         // given
         List<Map<?, ?>> resultItems = createPagedResultDocuments();
         Map<String, Object> pagedData = createSearchResults(resultItems, 1, 1);
-        WIRE_MOCK_SERVER.stubFor(get(urlEqualTo("/documents?query=test&limit=1")).willReturn(
+        WIRE_MOCK_SERVER.stubFor(get(urlEqualTo("/documents/graph-search?query=test&limit=1")).willReturn(
                 ok().withBody(MAPPER.writeValueAsString(pagedData))));
 
         StartingSearchFetcher fetcher = new StartingSearchFetcher();
@@ -209,7 +209,7 @@ public class TestStartingSearchFetcher {
         // then
         Assert.assertNotNull(actualList);
         Assert.assertFalse(actualList.isEmpty());
-        WIRE_MOCK_SERVER.verify(getRequestedFor(urlEqualTo("/documents?query=test&limit=1")));
+        WIRE_MOCK_SERVER.verify(getRequestedFor(urlEqualTo("/documents/graph-search?query=test&limit=1")));
         // and
         Assert.assertTrue(actualList.stream().anyMatch(n -> n.getUri().equals("subject")));
     }
@@ -220,7 +220,7 @@ public class TestStartingSearchFetcher {
         // given
         List<Map<?, ?>> resultItems = createPagedResultDocuments();
         Map<String, Object> pagedData = createSearchResults(resultItems, 1, 1);
-        WIRE_MOCK_SERVER.stubFor(get(urlEqualTo("/documents?query=test&limit=1")).willReturn(
+        WIRE_MOCK_SERVER.stubFor(get(urlEqualTo("/documents/graph-search?query=test&limit=1")).willReturn(
                 ok().withBody(MAPPER.writeValueAsString(pagedData))));
 
         StartingSearchWithMetadataFetcher fetcher = new StartingSearchWithMetadataFetcher();
@@ -237,7 +237,7 @@ public class TestStartingSearchFetcher {
         // then
         Assert.assertNotNull(results);
         Assert.assertFalse(results.getNodes().isEmpty());
-        WIRE_MOCK_SERVER.verify(getRequestedFor(urlEqualTo("/documents?query=test&limit=1")));
+        WIRE_MOCK_SERVER.verify(getRequestedFor(urlEqualTo("/documents/graph-search?query=test&limit=1")));
         // and
         Assert.assertEquals(results.getLimit(), 1);
         Assert.assertEquals(results.getOffset(), 1);
@@ -251,7 +251,7 @@ public class TestStartingSearchFetcher {
         // given
         List<Map<?, ?>> resultItems = createPagedResultDocuments();
         Map<String, Object> pagedData = createSearchResults(resultItems, 2, resultItems.size());
-        WIRE_MOCK_SERVER.stubFor(get(urlEqualTo("/documents?query=test&offset=2")).willReturn(
+        WIRE_MOCK_SERVER.stubFor(get(urlEqualTo("/documents/graph-search?query=test&offset=2")).willReturn(
                 ok().withBody(MAPPER.writeValueAsString(pagedData))));
 
         StartingSearchFetcher fetcher = new StartingSearchFetcher();
@@ -268,7 +268,7 @@ public class TestStartingSearchFetcher {
         // then
         Assert.assertNotNull(actualList);
         Assert.assertFalse(actualList.isEmpty());
-        WIRE_MOCK_SERVER.verify(getRequestedFor(urlEqualTo("/documents?query=test&offset=2")));
+        WIRE_MOCK_SERVER.verify(getRequestedFor(urlEqualTo("/documents/graph-search?query=test&offset=2")));
         // and
         Assert.assertTrue(actualList.stream().anyMatch(n -> n.getUri().equals("subject2")));
     }
@@ -279,7 +279,7 @@ public class TestStartingSearchFetcher {
         // given
         List<Map<?, ?>> resultItems = createPagedResultDocuments();
         Map<String, Object> pagedData = createSearchResults(resultItems, 2, resultItems.size());
-        WIRE_MOCK_SERVER.stubFor(get(urlEqualTo("/documents?query=test&offset=2")).willReturn(
+        WIRE_MOCK_SERVER.stubFor(get(urlEqualTo("/documents/graph-search?query=test&offset=2")).willReturn(
                 ok().withBody(MAPPER.writeValueAsString(pagedData))));
 
         StartingSearchWithMetadataFetcher fetcher = new StartingSearchWithMetadataFetcher();
@@ -296,7 +296,7 @@ public class TestStartingSearchFetcher {
         // then
         Assert.assertNotNull(results);
         Assert.assertFalse(results.getNodes().isEmpty());
-        WIRE_MOCK_SERVER.verify(getRequestedFor(urlEqualTo("/documents?query=test&offset=2")));
+        WIRE_MOCK_SERVER.verify(getRequestedFor(urlEqualTo("/documents/graph-search?query=test&offset=2")));
         // and
         Assert.assertEquals(results.getLimit(), 3);
         Assert.assertEquals(results.getOffset(), 2);
@@ -309,7 +309,7 @@ public class TestStartingSearchFetcher {
         // given
         List<Map<?, ?>> resultItems = createPagedResultDocuments();
         Map<String, Object> pagedData = createSearchResults(resultItems, 4, 1);
-        WIRE_MOCK_SERVER.stubFor(get(urlEqualTo("/documents?query=test&limit=1&offset=4")).willReturn(
+        WIRE_MOCK_SERVER.stubFor(get(urlEqualTo("/documents/graph-search?query=test&limit=1&offset=4")).willReturn(
                 ok().withBody(MAPPER.writeValueAsString(pagedData))));
 
         StartingSearchFetcher fetcher = new StartingSearchFetcher();
@@ -327,7 +327,7 @@ public class TestStartingSearchFetcher {
         // then
         Assert.assertNotNull(actualList);
         Assert.assertTrue(actualList.isEmpty());
-        WIRE_MOCK_SERVER.verify(getRequestedFor(urlEqualTo("/documents?query=test&limit=1&offset=4")));
+        WIRE_MOCK_SERVER.verify(getRequestedFor(urlEqualTo("/documents/graph-search?query=test&limit=1&offset=4")));
     }
 
     @Test
@@ -336,7 +336,7 @@ public class TestStartingSearchFetcher {
         // given
         List<Map<?, ?>> resultItems = createPagedResultDocuments();
         Map<String, Object> pagedData = createSearchResults(resultItems, 4, 1);
-        WIRE_MOCK_SERVER.stubFor(get(urlEqualTo("/documents?query=test&limit=1&offset=4")).willReturn(
+        WIRE_MOCK_SERVER.stubFor(get(urlEqualTo("/documents/graph-search?query=test&limit=1&offset=4")).willReturn(
                 ok().withBody(MAPPER.writeValueAsString(pagedData))));
 
         StartingSearchWithMetadataFetcher fetcher = new StartingSearchWithMetadataFetcher();
@@ -357,7 +357,7 @@ public class TestStartingSearchFetcher {
         Assert.assertEquals(results.getOffset(), 4);
         Assert.assertFalse(results.isMaybeMore());
         Assert.assertTrue(results.getNodes().isEmpty());
-        WIRE_MOCK_SERVER.verify(getRequestedFor(urlEqualTo("/documents?query=test&limit=1&offset=4")));
+        WIRE_MOCK_SERVER.verify(getRequestedFor(urlEqualTo("/documents/graph-search?query=test&limit=1&offset=4")));
     }
 
     @Test(expectedExceptions = RuntimeException.class)

--- a/telicent-graph-schema/src/test/java/io/telicent/jena/graphql/fetchers/telicent/graph/TestStartingSearchFetcher.java
+++ b/telicent-graph-schema/src/test/java/io/telicent/jena/graphql/fetchers/telicent/graph/TestStartingSearchFetcher.java
@@ -84,7 +84,7 @@ public class TestStartingSearchFetcher {
     @Test(expectedExceptions = RuntimeException.class)
     public void givenBadSearchResponse_whenUsingSearchFetcher_thenErrorIsThrown() {
         // given
-        WIRE_MOCK_SERVER.stubFor(get(urlEqualTo("/documents/graph-search?query=test")).willReturn(notFound()));
+        WIRE_MOCK_SERVER.stubFor(get(urlEqualTo("/documents/uri-search?query=test")).willReturn(notFound()));
 
         StartingSearchFetcher fetcher = new StartingSearchFetcher();
         DatasetGraph dsg = DatasetGraphFactory.create();
@@ -108,7 +108,7 @@ public class TestStartingSearchFetcher {
     public void givenEmptySearchResponse_whenUsingSearchFetcher_thenSuccess() {
         // given
         System.setProperty("SEARCH_API_URL", "http://localhost:8181/");
-        WIRE_MOCK_SERVER.stubFor(get(urlEqualTo("/documents/graph-search?query=test")).willReturn(ok().withBody("{}")));
+        WIRE_MOCK_SERVER.stubFor(get(urlEqualTo("/documents/uri-search?query=test")).willReturn(ok().withBody("{}")));
 
         StartingSearchFetcher fetcher = new StartingSearchFetcher();
         DatasetGraph dsg = DatasetGraphFactory.create();
@@ -128,7 +128,7 @@ public class TestStartingSearchFetcher {
         // then
         Assert.assertNotNull(actualList);
         Assert.assertTrue(actualList.isEmpty());
-        WIRE_MOCK_SERVER.verify(getRequestedFor(urlEqualTo("/documents/graph-search?query=test")));
+        WIRE_MOCK_SERVER.verify(getRequestedFor(urlEqualTo("/documents/uri-search?query=test")));
     }
 
     @Test
@@ -139,7 +139,7 @@ public class TestStartingSearchFetcher {
                                                                                         emptyMap(), Map.of("document",
                                                                                                            Map.of("something",
                                                                                                                   "else"))));
-        WIRE_MOCK_SERVER.stubFor(get(urlEqualTo("/documents/graph-search?query=test")).willReturn(
+        WIRE_MOCK_SERVER.stubFor(get(urlEqualTo("/documents/uri-search?query=test")).willReturn(
                 ok().withBody(MAPPER.writeValueAsString(returnedData))));
 
         StartingSearchFetcher fetcher = new StartingSearchFetcher();
@@ -157,7 +157,7 @@ public class TestStartingSearchFetcher {
         // then
         Assert.assertNotNull(actualList);
         Assert.assertFalse(actualList.isEmpty());
-        WIRE_MOCK_SERVER.verify(getRequestedFor(urlEqualTo("/documents/graph-search?query=test")));
+        WIRE_MOCK_SERVER.verify(getRequestedFor(urlEqualTo("/documents/uri-search?query=test")));
     }
 
     private static List<Map<?, ?>> createPagedResultDocuments() {
@@ -192,7 +192,7 @@ public class TestStartingSearchFetcher {
         // given
         List<Map<?, ?>> resultItems = createPagedResultDocuments();
         Map<String, Object> pagedData = createSearchResults(resultItems, 1, 1);
-        WIRE_MOCK_SERVER.stubFor(get(urlEqualTo("/documents/graph-search?query=test&limit=1")).willReturn(
+        WIRE_MOCK_SERVER.stubFor(get(urlEqualTo("/documents/uri-search?query=test&limit=1")).willReturn(
                 ok().withBody(MAPPER.writeValueAsString(pagedData))));
 
         StartingSearchFetcher fetcher = new StartingSearchFetcher();
@@ -209,7 +209,7 @@ public class TestStartingSearchFetcher {
         // then
         Assert.assertNotNull(actualList);
         Assert.assertFalse(actualList.isEmpty());
-        WIRE_MOCK_SERVER.verify(getRequestedFor(urlEqualTo("/documents/graph-search?query=test&limit=1")));
+        WIRE_MOCK_SERVER.verify(getRequestedFor(urlEqualTo("/documents/uri-search?query=test&limit=1")));
         // and
         Assert.assertTrue(actualList.stream().anyMatch(n -> n.getUri().equals("subject")));
     }
@@ -220,7 +220,7 @@ public class TestStartingSearchFetcher {
         // given
         List<Map<?, ?>> resultItems = createPagedResultDocuments();
         Map<String, Object> pagedData = createSearchResults(resultItems, 1, 1);
-        WIRE_MOCK_SERVER.stubFor(get(urlEqualTo("/documents/graph-search?query=test&limit=1")).willReturn(
+        WIRE_MOCK_SERVER.stubFor(get(urlEqualTo("/documents/uri-search?query=test&limit=1")).willReturn(
                 ok().withBody(MAPPER.writeValueAsString(pagedData))));
 
         StartingSearchWithMetadataFetcher fetcher = new StartingSearchWithMetadataFetcher();
@@ -237,7 +237,7 @@ public class TestStartingSearchFetcher {
         // then
         Assert.assertNotNull(results);
         Assert.assertFalse(results.getNodes().isEmpty());
-        WIRE_MOCK_SERVER.verify(getRequestedFor(urlEqualTo("/documents/graph-search?query=test&limit=1")));
+        WIRE_MOCK_SERVER.verify(getRequestedFor(urlEqualTo("/documents/uri-search?query=test&limit=1")));
         // and
         Assert.assertEquals(results.getLimit(), 1);
         Assert.assertEquals(results.getOffset(), 1);
@@ -251,7 +251,7 @@ public class TestStartingSearchFetcher {
         // given
         List<Map<?, ?>> resultItems = createPagedResultDocuments();
         Map<String, Object> pagedData = createSearchResults(resultItems, 2, resultItems.size());
-        WIRE_MOCK_SERVER.stubFor(get(urlEqualTo("/documents/graph-search?query=test&offset=2")).willReturn(
+        WIRE_MOCK_SERVER.stubFor(get(urlEqualTo("/documents/uri-search?query=test&offset=2")).willReturn(
                 ok().withBody(MAPPER.writeValueAsString(pagedData))));
 
         StartingSearchFetcher fetcher = new StartingSearchFetcher();
@@ -268,7 +268,7 @@ public class TestStartingSearchFetcher {
         // then
         Assert.assertNotNull(actualList);
         Assert.assertFalse(actualList.isEmpty());
-        WIRE_MOCK_SERVER.verify(getRequestedFor(urlEqualTo("/documents/graph-search?query=test&offset=2")));
+        WIRE_MOCK_SERVER.verify(getRequestedFor(urlEqualTo("/documents/uri-search?query=test&offset=2")));
         // and
         Assert.assertTrue(actualList.stream().anyMatch(n -> n.getUri().equals("subject2")));
     }
@@ -279,7 +279,7 @@ public class TestStartingSearchFetcher {
         // given
         List<Map<?, ?>> resultItems = createPagedResultDocuments();
         Map<String, Object> pagedData = createSearchResults(resultItems, 2, resultItems.size());
-        WIRE_MOCK_SERVER.stubFor(get(urlEqualTo("/documents/graph-search?query=test&offset=2")).willReturn(
+        WIRE_MOCK_SERVER.stubFor(get(urlEqualTo("/documents/uri-search?query=test&offset=2")).willReturn(
                 ok().withBody(MAPPER.writeValueAsString(pagedData))));
 
         StartingSearchWithMetadataFetcher fetcher = new StartingSearchWithMetadataFetcher();
@@ -296,7 +296,7 @@ public class TestStartingSearchFetcher {
         // then
         Assert.assertNotNull(results);
         Assert.assertFalse(results.getNodes().isEmpty());
-        WIRE_MOCK_SERVER.verify(getRequestedFor(urlEqualTo("/documents/graph-search?query=test&offset=2")));
+        WIRE_MOCK_SERVER.verify(getRequestedFor(urlEqualTo("/documents/uri-search?query=test&offset=2")));
         // and
         Assert.assertEquals(results.getLimit(), 3);
         Assert.assertEquals(results.getOffset(), 2);
@@ -309,7 +309,7 @@ public class TestStartingSearchFetcher {
         // given
         List<Map<?, ?>> resultItems = createPagedResultDocuments();
         Map<String, Object> pagedData = createSearchResults(resultItems, 4, 1);
-        WIRE_MOCK_SERVER.stubFor(get(urlEqualTo("/documents/graph-search?query=test&limit=1&offset=4")).willReturn(
+        WIRE_MOCK_SERVER.stubFor(get(urlEqualTo("/documents/uri-search?query=test&limit=1&offset=4")).willReturn(
                 ok().withBody(MAPPER.writeValueAsString(pagedData))));
 
         StartingSearchFetcher fetcher = new StartingSearchFetcher();
@@ -327,7 +327,7 @@ public class TestStartingSearchFetcher {
         // then
         Assert.assertNotNull(actualList);
         Assert.assertTrue(actualList.isEmpty());
-        WIRE_MOCK_SERVER.verify(getRequestedFor(urlEqualTo("/documents/graph-search?query=test&limit=1&offset=4")));
+        WIRE_MOCK_SERVER.verify(getRequestedFor(urlEqualTo("/documents/uri-search?query=test&limit=1&offset=4")));
     }
 
     @Test
@@ -336,7 +336,7 @@ public class TestStartingSearchFetcher {
         // given
         List<Map<?, ?>> resultItems = createPagedResultDocuments();
         Map<String, Object> pagedData = createSearchResults(resultItems, 4, 1);
-        WIRE_MOCK_SERVER.stubFor(get(urlEqualTo("/documents/graph-search?query=test&limit=1&offset=4")).willReturn(
+        WIRE_MOCK_SERVER.stubFor(get(urlEqualTo("/documents/uri-search?query=test&limit=1&offset=4")).willReturn(
                 ok().withBody(MAPPER.writeValueAsString(pagedData))));
 
         StartingSearchWithMetadataFetcher fetcher = new StartingSearchWithMetadataFetcher();
@@ -357,7 +357,7 @@ public class TestStartingSearchFetcher {
         Assert.assertEquals(results.getOffset(), 4);
         Assert.assertFalse(results.isMaybeMore());
         Assert.assertTrue(results.getNodes().isEmpty());
-        WIRE_MOCK_SERVER.verify(getRequestedFor(urlEqualTo("/documents/graph-search?query=test&limit=1&offset=4")));
+        WIRE_MOCK_SERVER.verify(getRequestedFor(urlEqualTo("/documents/uri-search?query=test&limit=1&offset=4")));
     }
 
     @Test(expectedExceptions = RuntimeException.class)


### PR DESCRIPTION
As per [CORE-1231](https://telicent.atlassian.net/browse/CORE-1231) which is in review [here](https://github.com/Telicent-io/smart-cache-search/pull/743), we were previously calling the general /documents endpoint but only ever using the Document's URI. 

To improve performance we can instead call a specific endpoint that will only return URIs (while applying the same security processing etc...). 

From reviewing the code, and in particular the flows from the GUI code, the new faster approach will not need a number of the Search Options as they are not ever executed. 

All of this is configurable so that should we need to go back, we can. 

Note: This obviously cannot be released until _after_ the next search release. I'm just doing the work now while fresh in mind. 

[CORE-1231]: https://telicent.atlassian.net/browse/CORE-1231?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ