### PR TITLE
[CORE-1249] De-duplicate Nodes when processing rdf:types in Relationship Type Facet fetcher. 

### DIFF
--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -28,6 +28,18 @@ time in milliseconds per operation:
 java -jar graphql-jena-benchmarks/target/benchmarks.jar -wi 2 -i 3 -f 1 -bm avgt -tu ms
 ```
 
+To focus on the relationship type facets benchmark:
+
+```bash
+java -jar graphql-jena-benchmarks/target/benchmarks.jar '.*RelationshipTypeFacetBenchmark.*' -wi 2 -i 5 -f 1 -bm avgt -tu ms
+```
+
+To compare allocation pressure and memory churn for the same benchmark:
+
+```bash
+java -jar graphql-jena-benchmarks/target/benchmarks.jar '.*RelationshipTypeFacetBenchmark.*' -wi 2 -i 5 -f 1 -bm avgt -tu ms -prof gc
+```
+
 ## Benchmark Tests Included
 
 Benchmarks are intentionally small and focus on core query execution paths:
@@ -44,6 +56,12 @@ Benchmarks are intentionally small and focus on core query execution paths:
   - `executeFriends`: runs `friends.graphql` over the same dataset.
   - These tests exercise `TraversalExecutor`, `TraversalEdgesFetcher`, and traversal wiring.
   - Expect roughly constant time for this fixed dataset unless traversal logic changes.
+
+- Relationship type facets (RelationshipTypeFacetBenchmark)
+  - `legacyTypeFacets`: simulates the previous implementation, which looked up `rdf:type` once per relationship.
+  - `optimizedTypeFacets`: measures the current implementation, which deduplicates related nodes first and looks up
+    `rdf:type` once per unique related node.
+  - This benchmark is the best direct measure of the type-facet optimization in the Telicent graph schema.
 
 Resources used by the benchmarks are stored under:
 

--- a/graphql-jena-benchmarks/pom.xml
+++ b/graphql-jena-benchmarks/pom.xml
@@ -25,6 +25,11 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>io.telicent.jena.graphql</groupId>
+            <artifactId>telicent-graph-schema</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.openjdk.jmh</groupId>
             <artifactId>jmh-core</artifactId>
             <version>${dependency.jmh}</version>

--- a/graphql-jena-benchmarks/src/main/java/io/telicent/jena/graphql/benchmarks/RelationshipTypeFacetBenchmark.java
+++ b/graphql-jena-benchmarks/src/main/java/io/telicent/jena/graphql/benchmarks/RelationshipTypeFacetBenchmark.java
@@ -1,0 +1,169 @@
+/**
+ * Copyright (C) Telicent Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.telicent.jena.graphql.benchmarks;
+
+import graphql.schema.DataFetchingEnvironment;
+import graphql.schema.DataFetchingEnvironmentImpl;
+import io.telicent.jena.graphql.execution.telicent.graph.TelicentExecutionContext;
+import io.telicent.jena.graphql.fetchers.telicent.graph.RelationshipTypeFacetsFetcher;
+import io.telicent.jena.graphql.schemas.models.EdgeDirection;
+import io.telicent.jena.graphql.schemas.telicent.graph.models.FacetInfo;
+import io.telicent.jena.graphql.schemas.telicent.graph.models.FacetInfoPlaceholder;
+import io.telicent.jena.graphql.schemas.telicent.graph.models.TelicentGraphNode;
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.sparql.core.DatasetGraph;
+import org.apache.jena.sparql.core.DatasetGraphFactory;
+import org.apache.jena.sparql.core.Quad;
+import org.apache.jena.vocabulary.RDF;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Benchmarks the relationship type facets fetcher before and after deduplicating related-node type lookups.
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Warmup(iterations = 2, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 3, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(1)
+public class RelationshipTypeFacetBenchmark {
+
+    /**
+     * Creates a relationship type facet benchmark.
+     */
+    public RelationshipTypeFacetBenchmark() {
+    }
+
+    /**
+     * Shared benchmark state.
+     */
+    @State(Scope.Benchmark)
+    public static class RelationshipTypeFacetState {
+
+        /**
+         * Total number of outbound relationships from the benchmark subject.
+         */
+        @Param({"100", "1000", "5000"})
+        public int relationshipCount;
+
+        private DatasetGraph dsg;
+        private DataFetchingEnvironment environment;
+        private RelationshipTypeFacetsFetcher optimizedFetcher;
+        private RelationshipTypeFacetsFetcher legacyFetcher;
+
+        /**
+         * Creates a benchmark state container.
+         */
+        public RelationshipTypeFacetState() {
+        }
+
+        /**
+         * Builds a synthetic dataset and fetchers for the benchmark.
+         */
+        @Setup
+        public void setup() {
+            this.dsg = DatasetGraphFactory.create();
+            Node source = NodeFactory.createURI("https://example.org/source");
+            generateDataset(this.dsg, source, this.relationshipCount);
+
+            TelicentExecutionContext context = new TelicentExecutionContext(this.dsg, "");
+            this.environment = DataFetchingEnvironmentImpl.newDataFetchingEnvironment()
+                                                         .localContext(context)
+                                                         .source(new FacetInfoPlaceholder(new TelicentGraphNode(source,
+                                                                                                                null),
+                                                                                          null, null))
+                                                         .arguments(Map.of())
+                                                         .build();
+            this.optimizedFetcher = new RelationshipTypeFacetsFetcher(EdgeDirection.OUT);
+            this.legacyFetcher = new LegacyRelationshipTypeFacetsFetcher();
+        }
+
+        private static void generateDataset(DatasetGraph dsg, Node source, int relationshipCount) {
+            Node graph = NodeFactory.createURI("https://example.org/graph");
+            int uniqueObjects = Math.max(1, relationshipCount / 10);
+            for (int i = 0; i < relationshipCount; i++) {
+                Node predicate = NodeFactory.createURI("https://example.org/predicate/" + (i % 12));
+                Node object = NodeFactory.createURI("https://example.org/object/" + (i % uniqueObjects));
+                dsg.add(new Quad(graph, source, predicate, object));
+            }
+            for (int i = 0; i < uniqueObjects; i++) {
+                Node object = NodeFactory.createURI("https://example.org/object/" + i);
+                dsg.add(new Quad(graph, object, RDF.type.asNode(),
+                                 NodeFactory.createURI("https://example.org/type/" + (i % 8))));
+                dsg.add(new Quad(graph, object, RDF.type.asNode(),
+                                 NodeFactory.createURI("https://example.org/type/" + ((i + 3) % 8))));
+            }
+        }
+    }
+
+    /**
+     * Measures the optimized type facets fetcher.
+     *
+     * @param state Shared benchmark state.
+     * @param blackhole JMH blackhole.
+     * @throws Exception If fetcher execution fails.
+     */
+    @Benchmark
+    public void optimizedTypeFacets(RelationshipTypeFacetState state, Blackhole blackhole) throws Exception {
+        List<FacetInfo> facets = state.optimizedFetcher.get(state.environment);
+        blackhole.consume(facets);
+    }
+
+    /**
+     * Measures the old behavior where types are looked up once per relationship.
+     *
+     * @param state Shared benchmark state.
+     * @param blackhole JMH blackhole.
+     * @throws Exception If fetcher execution fails.
+     */
+    @Benchmark
+    public void legacyTypeFacets(RelationshipTypeFacetState state, Blackhole blackhole) throws Exception {
+        List<FacetInfo> facets = state.legacyFetcher.get(state.environment);
+        blackhole.consume(facets);
+    }
+
+    private static final class LegacyRelationshipTypeFacetsFetcher extends RelationshipTypeFacetsFetcher {
+
+        private LegacyRelationshipTypeFacetsFetcher() {
+            super(EdgeDirection.OUT);
+        }
+
+        @Override
+        protected List<FacetInfo> map(DataFetchingEnvironment environment, DatasetGraph dsg, TelicentGraphNode node,
+                                      Stream<Quad> input) {
+            return input.flatMap(q -> streamTypes(dsg, getRelatedNode(q)))
+                        .collect(Collectors.groupingBy(Quad::getObject, Collectors.counting()))
+                        .entrySet()
+                        .stream()
+                        .map(e -> new FacetInfo(e.getKey(), dsg.prefixes(), e.getValue().intValue()))
+                        .toList();
+        }
+    }
+}

--- a/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/fetchers/telicent/graph/RelationshipTypeFacetsFetcher.java
+++ b/telicent-graph-schema/src/main/java/io/telicent/jena/graphql/fetchers/telicent/graph/RelationshipTypeFacetsFetcher.java
@@ -23,8 +23,9 @@ import org.apache.jena.sparql.core.DatasetGraph;
 import org.apache.jena.sparql.core.Quad;
 import org.apache.jena.vocabulary.RDF;
 
+import java.util.HashMap;
 import java.util.List;
-import java.util.stream.Collectors;
+import java.util.Map;
 import java.util.stream.Stream;
 
 /**
@@ -50,13 +51,40 @@ public class RelationshipTypeFacetsFetcher extends AbstractRelationshipsFetcher<
     @Override
     protected List<FacetInfo> map(DataFetchingEnvironment environment, DatasetGraph dsg, TelicentGraphNode node,
                                   Stream<Quad> input) {
-        return input.flatMap(q -> dsg.stream(Node.ANY, this.direction == EdgeDirection.IN ? q.getSubject() : q.getObject(), RDF.type.asNode(),
-                                             Node.ANY))
-                    .collect(Collectors.groupingBy(Quad::getObject, Collectors.counting()))
-                    .entrySet()
-                    .stream()
-                    .map(e -> new FacetInfo(e.getKey(), dsg.prefixes(), e.getValue().intValue()))
-                    .toList();
+        Map<Node, Integer> relatedNodeCounts = new HashMap<>();
+        input.forEach(q -> relatedNodeCounts.merge(getRelatedNode(q), 1, Integer::sum));
+
+        Map<Node, Integer> typeFacetCounts = new HashMap<>();
+        for (Map.Entry<Node, Integer> entry : relatedNodeCounts.entrySet()) {
+            streamTypes(dsg, entry.getKey()).forEach(q -> typeFacetCounts.merge(q.getObject(), entry.getValue(),
+                                                                                Integer::sum));
+        }
+
+        return typeFacetCounts.entrySet()
+                              .stream()
+                              .map(e -> new FacetInfo(e.getKey(), dsg.prefixes(), e.getValue()))
+                              .toList();
+    }
+
+    /**
+     * Gets the related node for a relationship quad.
+     *
+     * @param relationship Relationship quad
+     * @return Related node
+     */
+    protected Node getRelatedNode(Quad relationship) {
+        return this.direction == EdgeDirection.IN ? relationship.getSubject() : relationship.getObject();
+    }
+
+    /**
+     * Streams the type quads for a related node.
+     *
+     * @param dsg         Dataset graph
+     * @param relatedNode Related node
+     * @return Stream of type quads
+     */
+    protected Stream<Quad> streamTypes(DatasetGraph dsg, Node relatedNode) {
+        return dsg.stream(Node.ANY, relatedNode, RDF.type.asNode(), Node.ANY);
     }
 
     @Override

--- a/telicent-graph-schema/src/test/java/io/telicent/jena/graphql/fetchers/telicent/graph/TestRelationshipTypeFacetsFetcher.java
+++ b/telicent-graph-schema/src/test/java/io/telicent/jena/graphql/fetchers/telicent/graph/TestRelationshipTypeFacetsFetcher.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright (C) Telicent Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.telicent.jena.graphql.fetchers.telicent.graph;
+
+import graphql.schema.DataFetchingEnvironment;
+import io.telicent.jena.graphql.schemas.models.EdgeDirection;
+import io.telicent.jena.graphql.schemas.telicent.graph.models.FacetInfo;
+import io.telicent.jena.graphql.schemas.telicent.graph.models.FacetInfoPlaceholder;
+import io.telicent.jena.graphql.schemas.telicent.graph.models.TelicentGraphNode;
+import org.apache.jena.graph.Node;
+import org.apache.jena.sparql.core.DatasetGraph;
+import org.apache.jena.sparql.core.DatasetGraphFactory;
+import org.apache.jena.sparql.core.Quad;
+import org.apache.jena.vocabulary.RDF;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
+
+import static org.apache.jena.graph.NodeFactory.createURI;
+
+public class TestRelationshipTypeFacetsFetcher extends AbstractFetcherTests {
+
+    private static final Node GRAPH = createURI("graph");
+
+    @Test
+    public void givenRepeatedRelationshipsToSameNode_whenFetchingTypeFacets_thenTypesAreLookedUpOncePerRelatedNode()
+            throws Exception {
+        // Given
+        DatasetGraph dsg = DatasetGraphFactory.create();
+        Node subject = createURI("subject");
+        Node object1 = createURI("object1");
+        Node object2 = createURI("object2");
+        Node predicate1 = createURI("predicate1");
+        Node predicate2 = createURI("predicate2");
+        Node type1 = createURI("type1");
+        Node type2 = createURI("type2");
+
+        dsg.add(new Quad(GRAPH, subject, predicate1, object1));
+        dsg.add(new Quad(GRAPH, subject, predicate2, object1));
+        dsg.add(new Quad(GRAPH, subject, predicate1, object2));
+
+        dsg.add(new Quad(GRAPH, object1, RDF.type.asNode(), type1));
+        dsg.add(new Quad(GRAPH, object1, RDF.type.asNode(), type2));
+        dsg.add(new Quad(GRAPH, object2, RDF.type.asNode(), type1));
+
+        AtomicInteger typeLookupCount = new AtomicInteger();
+        RelationshipTypeFacetsFetcher fetcher = new RelationshipTypeFacetsFetcher(EdgeDirection.OUT) {
+            @Override
+            protected Stream<Quad> streamTypes(DatasetGraph dsg, Node relatedNode) {
+                typeLookupCount.incrementAndGet();
+                return super.streamTypes(dsg, relatedNode);
+            }
+        };
+
+        DataFetchingEnvironment environment = prepareFetchingEnvironment(dsg,
+                                                                         new FacetInfoPlaceholder(
+                                                                                 new TelicentGraphNode(subject, null),
+                                                                                 null, null),
+                                                                         Map.of());
+
+        // When
+        List<FacetInfo> facets = fetcher.get(environment);
+
+        // Then
+        Assert.assertEquals(typeLookupCount.get(), 2,
+                            "Expected type lookups to run once per unique related node");
+        Assert.assertEquals(facets.size(), 2);
+        Assert.assertEquals(facets.stream().collect(java.util.stream.Collectors.toMap(FacetInfo::getUri,
+                                                                                      FacetInfo::getCount)),
+                            Map.of("type1", 3, "type2", 2));
+    }
+}


### PR DESCRIPTION
Adding benchmarks too.