### PR TITLE
Use named Maven Central deployments and reduce release size

### DIFF
--- a/graphql-fuseki-module/pom.xml
+++ b/graphql-fuseki-module/pom.xml
@@ -45,6 +45,10 @@
                     <groupId>org.eclipse.jetty.ee11</groupId>
                     <artifactId>jetty-security</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.bouncycastle</groupId>
+                    <artifactId>bcprov-jdk18on</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 

--- a/graphql-jena-core/pom.xml
+++ b/graphql-jena-core/pom.xml
@@ -13,6 +13,7 @@
 
     <properties>
         <license.header.path>${project.parent.basedir}</license.header.path>
+        <skip.testJars>false</skip.testJars>
     </properties>
 
     <dependencies>

--- a/graphql-server/pom.xml
+++ b/graphql-server/pom.xml
@@ -12,6 +12,7 @@
 
     <properties>
         <license.header.path>${project.parent.basedir}</license.header.path>
+        <skipPublishing>true</skipPublishing>
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -479,6 +479,7 @@
                 <configuration>
                     <outputName>${project.artifactId}-${project.version}-bom</outputName>
                     <skipNotDeployed>false</skipNotDeployed> <!-- Forces SBOM generation -->
+                    <outputFormat>json</outputFormat>
                 </configuration>
             </plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,13 @@
         <coverage.minimum>0.9</coverage.minimum>
         <coverage.skip>false</coverage.skip>
 
+        <!-- Skipping of test JARs -->
+        <!--
+        Test and Test Source JARs will not be produced by default, modules can set this property to false if they have
+        reusable test code they want to make available to downstream consumers
+        -->
+        <skip.testJars>true</skip.testJars>
+
         <!-- Plugin Versions -->
         <plugin.central>0.11.0</plugin.central>
         <plugin.compiler>3.15.0</plugin.compiler>
@@ -260,6 +267,10 @@
                         <goals>
                             <goal>test-jar</goal>
                         </goals>
+                        <configuration>
+                            <skipIfEmpty>true</skipIfEmpty>
+                            <skip>${skip.testJars}</skip>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>
@@ -495,6 +506,7 @@
                     <autoPublish>true</autoPublish>
                     <waitUntil>validated</waitUntil>
                     <deploymentName>GraphQL Jena Extensions ${project.version}</deploymentName>
+                    <checksums>required</checksums>
                 </configuration>
             </plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -494,6 +494,7 @@
                     <publishingServerId>central</publishingServerId>
                     <autoPublish>true</autoPublish>
                     <waitUntil>validated</waitUntil>
+                    <deploymentName>GraphQL Jena Extensions ${project.version}</deploymentName>
                 </configuration>
             </plugin>
 


### PR DESCRIPTION
See telicent-oss/smart-caches-core#341 for context on the named deployments

Release size reductions:

- Only publish SBOMs in JSON format
- Don't create `tests` and `test-sources` JARs for modules that don't require them
- Only publish minimum required checksums